### PR TITLE
Fix: Add boundary checks for k and fetch_k

### DIFF
--- a/langchain_hana/utils.py
+++ b/langchain_hana/utils.py
@@ -10,3 +10,14 @@ class DistanceStrategy(str, Enum):
     DOT_PRODUCT = "DOT_PRODUCT"
     JACCARD = "JACCARD"
     COSINE = "COSINE"
+
+def _validate_k(k : int):
+    if not isinstance(k, int) or k <= 0:
+        raise ValueError("Parameter 'k' must be an integer greater than 0")
+
+def _validate_k_and_fetch_k(k: int, fetch_k: int):
+    _validate_k(k)
+    if not isinstance(fetch_k, int) or fetch_k < k:
+        raise ValueError(
+            "Parameter 'fetch_k' must be an integer greater than or equal to 'k'"
+        )

--- a/langchain_hana/utils.py
+++ b/langchain_hana/utils.py
@@ -11,9 +11,11 @@ class DistanceStrategy(str, Enum):
     JACCARD = "JACCARD"
     COSINE = "COSINE"
 
-def _validate_k(k : int):
+
+def _validate_k(k: int):
     if not isinstance(k, int) or k <= 0:
         raise ValueError("Parameter 'k' must be an integer greater than 0")
+
 
 def _validate_k_and_fetch_k(k: int, fetch_k: int):
     _validate_k(k)

--- a/langchain_hana/vectorstores.py
+++ b/langchain_hana/vectorstores.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import re
 import struct
+from functools import wraps
 from typing import (
     Any,
     Callable,
@@ -338,6 +340,105 @@ class HanaDB(VectorStore):
         error_message += f"Minimum required instance version: {min_instance_version}"
 
         raise ValueError(error_message)
+
+    def _validate_k(func):
+        # Inspect function signature once at decoration time
+        sig = inspect.signature(func)
+        params = list(sig.parameters.keys())
+
+        if "k" not in params:
+            raise ValueError(f"'k' parameter not found in function {func.__name__}")
+
+        k_index = params.index("k")
+        k_param = sig.parameters["k"]
+        k_default = (
+            k_param.default if k_param.default is not inspect.Parameter.empty else None
+        )
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            # Extract k from keyword args if present
+            if "k" in kwargs:
+                k = kwargs["k"]
+            # Else from positional args if present
+            elif len(args) > k_index:
+                k = args[k_index]
+            # Else use default if available
+            elif k_default is not None:
+                k = k_default
+            else:
+                raise ValueError("Parameter 'k' must be provided")
+
+            # Validate k
+            if k <= 0:
+                raise ValueError("Parameter 'k' must be an integer greater than 0")
+
+            # Call the original function with original args and kwargs
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    def _validate_k_and_fetch_k(func):
+        sig = inspect.signature(func)
+        params = list(sig.parameters.keys())
+
+        if "k" not in params:
+            raise ValueError(f"'k' parameter not found in function {func.__name__}")
+        if "fetch_k" not in params:
+            raise ValueError(
+                f"'fetch_k' parameter not found in function {func.__name__}"
+            )
+
+        k_index = params.index("k")
+        fetch_k_index = params.index("fetch_k")
+
+        k_param = sig.parameters["k"]
+        fetch_k_param = sig.parameters["fetch_k"]
+
+        k_default = (
+            k_param.default if k_param.default is not inspect.Parameter.empty else None
+        )
+        fetch_k_default = (
+            fetch_k_param.default
+            if fetch_k_param.default is not inspect.Parameter.empty
+            else None
+        )
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            # Extract k
+            if "k" in kwargs:
+                k = kwargs["k"]
+            elif len(args) > k_index:
+                k = args[k_index]
+            elif k_default is not None:
+                k = k_default
+            else:
+                raise ValueError("Parameter 'k' must be provided")
+
+            # Extract fetch_k
+            if "fetch_k" in kwargs:
+                fetch_k = kwargs["fetch_k"]
+            elif len(args) > fetch_k_index:
+                fetch_k = args[fetch_k_index]
+            elif fetch_k_default is not None:
+                fetch_k = fetch_k_default
+            else:
+                raise ValueError("Parameter 'fetch_k' must be provided")
+
+            # Validate k
+            if not isinstance(k, int) or k <= 0:
+                raise ValueError("Parameter 'k' must be an integer greater than 0")
+
+            # Validate fetch_k
+            if fetch_k < k:
+                raise ValueError(
+                    "Parameter 'fetch_k' must be an integer greater than or equal to 'k'"
+                )
+
+            return func(*args, **kwargs)
+
+        return wrapper
 
     def _serialize_binary_format(self, values: list[float]) -> bytes:
         # Converts a list of floats into binary format
@@ -686,6 +787,7 @@ class HanaDB(VectorStore):
         instance.add_texts(texts, metadatas)
         return instance
 
+    @_validate_k
     def similarity_search(  # type: ignore[override]
         self, query: str, k: int = 4, filter: Optional[dict] = None
     ) -> list[Document]:
@@ -833,7 +935,6 @@ class HanaDB(VectorStore):
             - list[float]: The document's embedding vector
         """
         result = []
-        k = HanaDB._sanitize_int(k)
         distance_func_name = HANA_DISTANCE_FUNCTION[self.distance_strategy][0]
 
         # Generate metadata projection for filtered results
@@ -965,6 +1066,7 @@ class HanaDB(VectorStore):
             f"FROM \"{self.table_name}\")"
         )
 
+    @_validate_k
     def similarity_search_by_vector(  # type: ignore[override]
         self, embedding: list[float], k: int = 4, filter: Optional[dict] = None
     ) -> list[Document]:
@@ -1057,6 +1159,7 @@ class HanaDB(VectorStore):
         finally:
             cur.close()
 
+    @_validate_k_and_fetch_k
     def max_marginal_relevance_search(  # type: ignore[override]
         self,
         query: str,
@@ -1103,6 +1206,7 @@ class HanaDB(VectorStore):
         array_wo_brackets = array_as_string[1:-1]
         return [float(x) for x in array_wo_brackets.split(",")]
 
+    @_validate_k_and_fetch_k
     def max_marginal_relevance_search_by_vector(  # type: ignore[override]
         self,
         embedding: list[float],

--- a/langchain_hana/vectorstores.py
+++ b/langchain_hana/vectorstores.py
@@ -687,7 +687,6 @@ class HanaDB(VectorStore):
         instance.add_texts(texts, metadatas)
         return instance
 
-
     def similarity_search(  # type: ignore[override]
         self, query: str, k: int = 4, filter: Optional[dict] = None
     ) -> list[Document]:

--- a/langchain_hana/vectorstores.py
+++ b/langchain_hana/vectorstores.py
@@ -1106,7 +1106,6 @@ class HanaDB(VectorStore):
         array_wo_brackets = array_as_string[1:-1]
         return [float(x) for x in array_wo_brackets.split(",")]
 
-    
     def max_marginal_relevance_search_by_vector(  # type: ignore[override]
         self,
         embedding: list[float],
@@ -1115,7 +1114,6 @@ class HanaDB(VectorStore):
         lambda_mult: float = 0.5,
         filter: Optional[dict] = None,
     ) -> list[Document]:
-
         _validate_k_and_fetch_k(k, fetch_k)
 
         whole_result = self.similarity_search_with_score_and_vector_by_vector(

--- a/langchain_hana/vectorstores.py
+++ b/langchain_hana/vectorstores.py
@@ -6,7 +6,6 @@ import json
 import logging
 import re
 import struct
-from functools import wraps
 from typing import (
     Any,
     Callable,

--- a/tests/integration_tests/test_vectorstores.py
+++ b/tests/integration_tests/test_vectorstores.py
@@ -289,6 +289,40 @@ def test_hanavector_similarity_search_simple(texts: List[str]) -> None:
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
+def test_hanavector_similarity_search_simple_invalid_k_zero(texts: list[str]) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        vectorDB.similarity_search(texts[0], 0)
+
+
+@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
+def test_hanavector_similarity_search_simple_invalid_k_negative(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        vectorDB.similarity_search(texts[0], -4)
+
+
+@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
 def test_hanavector_similarity_search_by_vector_simple(texts: List[str]) -> None:
     table_name = "TEST_TABLE_SEARCH_SIMPLE_VECTOR"
 
@@ -302,6 +336,43 @@ def test_hanavector_similarity_search_by_vector_simple(texts: List[str]) -> None
     vector = embedding.embed_query(texts[0])
     assert texts[0] == vectorDB.similarity_search_by_vector(vector, 1)[0].page_content
     assert texts[1] != vectorDB.similarity_search_by_vector(vector, 1)[0].page_content
+
+
+@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
+def test_hanavector_similarity_search_by_vector_simple_invalid_k_zero(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    vector = embedding.embed_query(texts[0])
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        vectorDB.similarity_search_by_vector(vector, 0)
+
+
+@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
+def test_hanavector_similarity_search_by_vector_simple_invalid_k_negative(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+    vector = embedding.embed_query(texts[0])
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        vectorDB.similarity_search_by_vector(vector, -4)
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
@@ -667,6 +738,60 @@ def test_hanavector_max_marginal_relevance_search(texts: List[str]) -> None:
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
+def test_hanavector_max_marginal_relevance_search_invalid_k_zero(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        vectorDB.max_marginal_relevance_search(texts[0], 0, 20)
+
+
+@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
+def test_hanavector_max_marginal_relevance_search_invalid_k_negative(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        vectorDB.max_marginal_relevance_search(texts[0], -5, 20)
+
+
+@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
+def test_hanavector_max_marginal_relevance_search_invalid_fetch_k_less_than_k(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="greater than or equal to 'k'"):
+        vectorDB.max_marginal_relevance_search(texts[0], 5, 1)
+
+
+@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
 def test_hanavector_max_marginal_relevance_search_vector(texts: List[str]) -> None:
     table_name = "TEST_TABLE_MAX_RELEVANCE_VECTOR"
 
@@ -706,6 +831,60 @@ async def test_hanavector_max_marginal_relevance_search_async(texts: List[str]) 
     assert len(search_result) == 2
     assert search_result[0].page_content == texts[0]
     assert search_result[1].page_content != texts[0]
+
+
+@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
+async def test_hanavector_max_marginal_relevance_search_async_invalid_k_zero(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        await vectorDB.amax_marginal_relevance_search(texts[0], 0, 20)
+
+
+@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
+async def test_hanavector_max_marginal_relevance_search_async_invalid_k_negative(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        await vectorDB.amax_marginal_relevance_search(texts[0], -5, 20)
+
+
+@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
+async def test_hanavector_max_marginal_relevance_search_async_invalid_fetch_k_less_than_k(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="greater than or equal to 'k'"):
+        await vectorDB.amax_marginal_relevance_search(texts[0], 5, 1)
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
@@ -855,7 +1034,10 @@ def test_hanavector_enhanced_filter_1() -> None:
     vectorDB.add_documents(DOCUMENTS)
 
 
-@pytest.mark.parametrize("test_filter, expected_ids, expected_where_clause, expected_where_clause_parameters", FILTERING_TEST_CASES)
+@pytest.mark.parametrize(
+    "test_filter, expected_ids, expected_where_clause, expected_where_clause_parameters",
+    FILTERING_TEST_CASES,
+)
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
 def test_hanavector_with_with_metadata_filters(
     test_filter: Dict[str, Any],

--- a/tests/integration_tests/test_vectorstores.py
+++ b/tests/integration_tests/test_vectorstores.py
@@ -289,8 +289,9 @@ def test_hanavector_similarity_search_simple(texts: List[str]) -> None:
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
-def test_hanavector_similarity_search_simple_invalid_k_zero(texts: list[str]) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+@pytest.mark.parametrize("k", [0, -4])
+def test_hanavector_similarity_search_simple_invalid(texts: list[str], k: int) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE_INVALID"
 
     # Check if table is created
     vectorDB = HanaDB.from_texts(
@@ -301,25 +302,7 @@ def test_hanavector_similarity_search_simple_invalid_k_zero(texts: list[str]) ->
     )
 
     with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        vectorDB.similarity_search(texts[0], 0)
-
-
-@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
-def test_hanavector_similarity_search_simple_invalid_k_negative(
-    texts: list[str],
-) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
-
-    # Check if table is created
-    vectorDB = HanaDB.from_texts(
-        connection=test_setup.conn,
-        texts=texts,
-        embedding=embedding,
-        table_name=table_name,
-    )
-
-    with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        vectorDB.similarity_search(texts[0], -4)
+        vectorDB.similarity_search(texts[0], k)
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
@@ -339,10 +322,9 @@ def test_hanavector_similarity_search_by_vector_simple(texts: List[str]) -> None
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
-def test_hanavector_similarity_search_by_vector_simple_invalid_k_zero(
-    texts: list[str],
-) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+@pytest.mark.parametrize("k", [0, -4])
+def test_hanavector_similarity_search_by_vector_simple_invalid(texts: list[str], k: int) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE_VECTOR_INVALID"
 
     # Check if table is created
     vectorDB = HanaDB.from_texts(
@@ -352,27 +334,8 @@ def test_hanavector_similarity_search_by_vector_simple_invalid_k_zero(
         table_name=table_name,
     )
 
-    vector = embedding.embed_query(texts[0])
     with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        vectorDB.similarity_search_by_vector(vector, 0)
-
-
-@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
-def test_hanavector_similarity_search_by_vector_simple_invalid_k_negative(
-    texts: list[str],
-) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
-
-    # Check if table is created
-    vectorDB = HanaDB.from_texts(
-        connection=test_setup.conn,
-        texts=texts,
-        embedding=embedding,
-        table_name=table_name,
-    )
-    vector = embedding.embed_query(texts[0])
-    with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        vectorDB.similarity_search_by_vector(vector, -4)
+        vectorDB.similarity_search_by_vector(texts[0], k)
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
@@ -738,10 +701,11 @@ def test_hanavector_max_marginal_relevance_search(texts: List[str]) -> None:
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
-def test_hanavector_max_marginal_relevance_search_invalid_k_zero(
-    texts: list[str],
+@pytest.mark.parametrize("k, fetch_k, error_msg", [(0, 20, "must be an integer greater than 0"), (-4, 20, "must be an integer greater than 0"), (2, 0, "greater than or equal to 'k'")])
+def test_hanavector_max_marginal_relevance_search_invalid(
+    texts: list[str], k: int, fetch_k: int, error_msg: str
 ) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+    table_name = "TEST_TABLE_MAX_RELEVANCE_INVALID"
 
     # Check if table is created
     vectorDB = HanaDB.from_texts(
@@ -751,44 +715,8 @@ def test_hanavector_max_marginal_relevance_search_invalid_k_zero(
         table_name=table_name,
     )
 
-    with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        vectorDB.max_marginal_relevance_search(texts[0], 0, 20)
-
-
-@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
-def test_hanavector_max_marginal_relevance_search_invalid_k_negative(
-    texts: list[str],
-) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
-
-    # Check if table is created
-    vectorDB = HanaDB.from_texts(
-        connection=test_setup.conn,
-        texts=texts,
-        embedding=embedding,
-        table_name=table_name,
-    )
-
-    with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        vectorDB.max_marginal_relevance_search(texts[0], -5, 20)
-
-
-@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
-def test_hanavector_max_marginal_relevance_search_invalid_fetch_k_less_than_k(
-    texts: list[str],
-) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
-
-    # Check if table is created
-    vectorDB = HanaDB.from_texts(
-        connection=test_setup.conn,
-        texts=texts,
-        embedding=embedding,
-        table_name=table_name,
-    )
-
-    with pytest.raises(ValueError, match="greater than or equal to 'k'"):
-        vectorDB.max_marginal_relevance_search(texts[0], 5, 1)
+    with pytest.raises(ValueError, match=error_msg):
+        vectorDB.max_marginal_relevance_search(texts[0], k, fetch_k)
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
@@ -834,10 +762,11 @@ async def test_hanavector_max_marginal_relevance_search_async(texts: List[str]) 
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
-async def test_hanavector_max_marginal_relevance_search_async_invalid_k_zero(
-    texts: list[str],
+@pytest.mark.parametrize("k, fetch_k, error_msg", [(0, 20, "must be an integer greater than 0"), (-4, 20, "must be an integer greater than 0"), (2, 0, "greater than or equal to 'k'")])
+async def test_hanavector_max_marginal_relevance_search_async_invalid(
+    texts: list[str], k: int, fetch_k: int, error_msg: str
 ) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+    table_name = "TEST_TABLE_MAX_RELEVANCE_INVALID"
 
     # Check if table is created
     vectorDB = HanaDB.from_texts(
@@ -847,44 +776,8 @@ async def test_hanavector_max_marginal_relevance_search_async_invalid_k_zero(
         table_name=table_name,
     )
 
-    with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        await vectorDB.amax_marginal_relevance_search(texts[0], 0, 20)
-
-
-@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
-async def test_hanavector_max_marginal_relevance_search_async_invalid_k_negative(
-    texts: list[str],
-) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
-
-    # Check if table is created
-    vectorDB = HanaDB.from_texts(
-        connection=test_setup.conn,
-        texts=texts,
-        embedding=embedding,
-        table_name=table_name,
-    )
-
-    with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        await vectorDB.amax_marginal_relevance_search(texts[0], -5, 20)
-
-
-@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
-async def test_hanavector_max_marginal_relevance_search_async_invalid_fetch_k_less_than_k(
-    texts: list[str],
-) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
-
-    # Check if table is created
-    vectorDB = HanaDB.from_texts(
-        connection=test_setup.conn,
-        texts=texts,
-        embedding=embedding,
-        table_name=table_name,
-    )
-
-    with pytest.raises(ValueError, match="greater than or equal to 'k'"):
-        await vectorDB.amax_marginal_relevance_search(texts[0], 5, 1)
+    with pytest.raises(ValueError, match=error_msg):
+        await vectorDB.amax_marginal_relevance_search(texts[0], k, fetch_k)
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")

--- a/tests/integration_tests/test_vectorstores.py
+++ b/tests/integration_tests/test_vectorstores.py
@@ -323,7 +323,9 @@ def test_hanavector_similarity_search_by_vector_simple(texts: List[str]) -> None
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
 @pytest.mark.parametrize("k", [0, -4])
-def test_hanavector_similarity_search_by_vector_simple_invalid(texts: list[str], k: int) -> None:
+def test_hanavector_similarity_search_by_vector_simple_invalid(
+    texts: list[str], k: int
+) -> None:
     table_name = "TEST_TABLE_SEARCH_SIMPLE_VECTOR_INVALID"
 
     # Check if table is created
@@ -701,7 +703,14 @@ def test_hanavector_max_marginal_relevance_search(texts: List[str]) -> None:
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
-@pytest.mark.parametrize("k, fetch_k, error_msg", [(0, 20, "must be an integer greater than 0"), (-4, 20, "must be an integer greater than 0"), (2, 0, "greater than or equal to 'k'")])
+@pytest.mark.parametrize(
+    "k, fetch_k, error_msg",
+    [
+        (0, 20, "must be an integer greater than 0"),
+        (-4, 20, "must be an integer greater than 0"),
+        (2, 0, "greater than or equal to 'k'"),
+    ],
+)
 def test_hanavector_max_marginal_relevance_search_invalid(
     texts: list[str], k: int, fetch_k: int, error_msg: str
 ) -> None:
@@ -762,7 +771,14 @@ async def test_hanavector_max_marginal_relevance_search_async(texts: List[str]) 
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
-@pytest.mark.parametrize("k, fetch_k, error_msg", [(0, 20, "must be an integer greater than 0"), (-4, 20, "must be an integer greater than 0"), (2, 0, "greater than or equal to 'k'")])
+@pytest.mark.parametrize(
+    "k, fetch_k, error_msg",
+    [
+        (0, 20, "must be an integer greater than 0"),
+        (-4, 20, "must be an integer greater than 0"),
+        (2, 0, "greater than or equal to 'k'"),
+    ],
+)
 async def test_hanavector_max_marginal_relevance_search_async_invalid(
     texts: list[str], k: int, fetch_k: int, error_msg: str
 ) -> None:

--- a/tests/integration_tests/test_vectorstores_internal_embedding.py
+++ b/tests/integration_tests/test_vectorstores_internal_embedding.py
@@ -153,8 +153,9 @@ def test_hanavector_similarity_search_with_metadata_filter(
     assert metadatas[1]["end"] == search_result[0].metadata["end"]
 
 
-def test_hanavector_similarity_search_simple_invalid_k_zero(texts: list[str]) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+@pytest.mark.parametrize("k", [0, -4])
+def test_hanavector_similarity_search_simple_invalid(texts: list[str], k: int) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE_INVALID"
 
     # Check if table is created
     vectorDB = HanaDB.from_texts(
@@ -165,24 +166,8 @@ def test_hanavector_similarity_search_simple_invalid_k_zero(texts: list[str]) ->
     )
 
     with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        vectorDB.similarity_search(texts[0], 0)
+        vectorDB.similarity_search(texts[0], k)       
 
-
-def test_hanavector_similarity_search_simple_invalid_k_negative(
-    texts: list[str],
-) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
-
-    # Check if table is created
-    vectorDB = HanaDB.from_texts(
-        connection=test_setup.conn,
-        texts=texts,
-        embedding=embedding,
-        table_name=table_name,
-    )
-
-    with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        vectorDB.similarity_search(texts[0], -4)
 
 def test_hanavector_max_marginal_relevance_search(texts: list[str]) -> None:
     table_name = "TEST_TABLE_MAX_RELEVANCE"
@@ -202,10 +187,11 @@ def test_hanavector_max_marginal_relevance_search(texts: list[str]) -> None:
     assert search_result[1].page_content != texts[0]
 
 
-def test_hanavector_max_marginal_relevance_search_invalid_k_zero(
-    texts: list[str],
+@pytest.mark.parametrize("k, fetch_k, error_msg", [(0, 20, "must be an integer greater than 0"), (-4, 20, "must be an integer greater than 0"), (2, 0, "greater than or equal to 'k'")])
+def test_hanavector_max_marginal_relevance_search_invalid(
+    texts: list[str], k: int, fetch_k: int, error_msg: str
 ) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+    table_name = "TEST_TABLE_MAX_RELEVANCE_INVALID"
 
     # Check if table is created
     vectorDB = HanaDB.from_texts(
@@ -215,14 +201,15 @@ def test_hanavector_max_marginal_relevance_search_invalid_k_zero(
         table_name=table_name,
     )
 
-    with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        vectorDB.max_marginal_relevance_search(texts[0], 0, 20)
+    with pytest.raises(ValueError, match=error_msg):
+        vectorDB.max_marginal_relevance_search(texts[0], k, fetch_k)
 
 
-def test_hanavector_max_marginal_relevance_search_invalid_k_negative(
-    texts: list[str],
+@pytest.mark.parametrize("k, fetch_k, error_msg", [(0, 20, "must be an integer greater than 0"), (-4, 20, "must be an integer greater than 0"), (2, 0, "greater than or equal to 'k'")])
+async def test_hanavector_max_marginal_relevance_search_async_invalid(
+    texts: list[str], k: int, fetch_k: int, error_msg: str
 ) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+    table_name = "TEST_TABLE_MAX_RELEVANCE_ASYNC_INVALID"
 
     # Check if table is created
     vectorDB = HanaDB.from_texts(
@@ -232,73 +219,5 @@ def test_hanavector_max_marginal_relevance_search_invalid_k_negative(
         table_name=table_name,
     )
 
-    with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        vectorDB.max_marginal_relevance_search(texts[0], -5, 20)
-
-
-def test_hanavector_max_marginal_relevance_search_invalid_fetch_k_less_than_k(
-    texts: list[str],
-) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
-
-    # Check if table is created
-    vectorDB = HanaDB.from_texts(
-        connection=test_setup.conn,
-        texts=texts,
-        embedding=embedding,
-        table_name=table_name,
-    )
-
-    with pytest.raises(ValueError, match="greater than or equal to 'k'"):
-        vectorDB.max_marginal_relevance_search(texts[0], 5, 1)
-
-
-async def test_hanavector_max_marginal_relevance_search_async_invalid_k_zero(
-    texts: list[str],
-) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
-
-    # Check if table is created
-    vectorDB = HanaDB.from_texts(
-        connection=test_setup.conn,
-        texts=texts,
-        embedding=embedding,
-        table_name=table_name,
-    )
-
-    with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        await vectorDB.amax_marginal_relevance_search(texts[0], 0, 20)
-
-
-async def test_hanavector_max_marginal_relevance_search_async_invalid_k_negative(
-    texts: list[str],
-) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
-
-    # Check if table is created
-    vectorDB = HanaDB.from_texts(
-        connection=test_setup.conn,
-        texts=texts,
-        embedding=embedding,
-        table_name=table_name,
-    )
-
-    with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        await vectorDB.amax_marginal_relevance_search(texts[0], -5, 20)
-
-
-async def test_hanavector_max_marginal_relevance_search_async_invalid_fetch_k_less_than_k(
-    texts: list[str],
-) -> None:
-    table_name = "TEST_TABLE_SEARCH_SIMPLE"
-
-    # Check if table is created
-    vectorDB = HanaDB.from_texts(
-        connection=test_setup.conn,
-        texts=texts,
-        embedding=embedding,
-        table_name=table_name,
-    )
-
-    with pytest.raises(ValueError, match="greater than or equal to 'k'"):
-        await vectorDB.amax_marginal_relevance_search(texts[0], 5, 1)
+    with pytest.raises(ValueError, match=error_msg):
+        await vectorDB.amax_marginal_relevance_search(texts[0], k, fetch_k)

--- a/tests/integration_tests/test_vectorstores_internal_embedding.py
+++ b/tests/integration_tests/test_vectorstores_internal_embedding.py
@@ -20,6 +20,7 @@ test_setup = ConfigData()
 
 embedding = None
 
+
 def is_internal_embedding_available(connection, embedding) -> bool:
     """
     Check if the internal embedding function is available in HANA DB.
@@ -166,7 +167,7 @@ def test_hanavector_similarity_search_simple_invalid(texts: list[str], k: int) -
     )
 
     with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        vectorDB.similarity_search(texts[0], k)       
+        vectorDB.similarity_search(texts[0], k)
 
 
 def test_hanavector_max_marginal_relevance_search(texts: list[str]) -> None:
@@ -187,7 +188,14 @@ def test_hanavector_max_marginal_relevance_search(texts: list[str]) -> None:
     assert search_result[1].page_content != texts[0]
 
 
-@pytest.mark.parametrize("k, fetch_k, error_msg", [(0, 20, "must be an integer greater than 0"), (-4, 20, "must be an integer greater than 0"), (2, 0, "greater than or equal to 'k'")])
+@pytest.mark.parametrize(
+    "k, fetch_k, error_msg",
+    [
+        (0, 20, "must be an integer greater than 0"),
+        (-4, 20, "must be an integer greater than 0"),
+        (2, 0, "greater than or equal to 'k'"),
+    ],
+)
 def test_hanavector_max_marginal_relevance_search_invalid(
     texts: list[str], k: int, fetch_k: int, error_msg: str
 ) -> None:
@@ -205,7 +213,14 @@ def test_hanavector_max_marginal_relevance_search_invalid(
         vectorDB.max_marginal_relevance_search(texts[0], k, fetch_k)
 
 
-@pytest.mark.parametrize("k, fetch_k, error_msg", [(0, 20, "must be an integer greater than 0"), (-4, 20, "must be an integer greater than 0"), (2, 0, "greater than or equal to 'k'")])
+@pytest.mark.parametrize(
+    "k, fetch_k, error_msg",
+    [
+        (0, 20, "must be an integer greater than 0"),
+        (-4, 20, "must be an integer greater than 0"),
+        (2, 0, "greater than or equal to 'k'"),
+    ],
+)
 async def test_hanavector_max_marginal_relevance_search_async_invalid(
     texts: list[str], k: int, fetch_k: int, error_msg: str
 ) -> None:

--- a/tests/integration_tests/test_vectorstores_internal_embedding.py
+++ b/tests/integration_tests/test_vectorstores_internal_embedding.py
@@ -20,7 +20,6 @@ test_setup = ConfigData()
 
 embedding = None
 
-
 def is_internal_embedding_available(connection, embedding) -> bool:
     """
     Check if the internal embedding function is available in HANA DB.
@@ -154,6 +153,37 @@ def test_hanavector_similarity_search_with_metadata_filter(
     assert metadatas[1]["end"] == search_result[0].metadata["end"]
 
 
+def test_hanavector_similarity_search_simple_invalid_k_zero(texts: list[str]) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        vectorDB.similarity_search(texts[0], 0)
+
+
+def test_hanavector_similarity_search_simple_invalid_k_negative(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        vectorDB.similarity_search(texts[0], -4)
+
 def test_hanavector_max_marginal_relevance_search(texts: list[str]) -> None:
     table_name = "TEST_TABLE_MAX_RELEVANCE"
 
@@ -170,3 +200,105 @@ def test_hanavector_max_marginal_relevance_search(texts: list[str]) -> None:
     assert len(search_result) == 2
     assert search_result[0].page_content == texts[0]
     assert search_result[1].page_content != texts[0]
+
+
+def test_hanavector_max_marginal_relevance_search_invalid_k_zero(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        vectorDB.max_marginal_relevance_search(texts[0], 0, 20)
+
+
+def test_hanavector_max_marginal_relevance_search_invalid_k_negative(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        vectorDB.max_marginal_relevance_search(texts[0], -5, 20)
+
+
+def test_hanavector_max_marginal_relevance_search_invalid_fetch_k_less_than_k(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="greater than or equal to 'k'"):
+        vectorDB.max_marginal_relevance_search(texts[0], 5, 1)
+
+
+async def test_hanavector_max_marginal_relevance_search_async_invalid_k_zero(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        await vectorDB.amax_marginal_relevance_search(texts[0], 0, 20)
+
+
+async def test_hanavector_max_marginal_relevance_search_async_invalid_k_negative(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        await vectorDB.amax_marginal_relevance_search(texts[0], -5, 20)
+
+
+async def test_hanavector_max_marginal_relevance_search_async_invalid_fetch_k_less_than_k(
+    texts: list[str],
+) -> None:
+    table_name = "TEST_TABLE_SEARCH_SIMPLE"
+
+    # Check if table is created
+    vectorDB = HanaDB.from_texts(
+        connection=test_setup.conn,
+        texts=texts,
+        embedding=embedding,
+        table_name=table_name,
+    )
+
+    with pytest.raises(ValueError, match="greater than or equal to 'k'"):
+        await vectorDB.amax_marginal_relevance_search(texts[0], 5, 1)

--- a/tests/unit_tests/test_vectorstores.py
+++ b/tests/unit_tests/test_vectorstores.py
@@ -55,7 +55,7 @@ def dummy_similarity_search(query, k=4):
         ("apple", None, "Query: apple, k=4"),
         ("banana", 3, "Query: banana, k=3"),
         ("cherry", 2, "Query: cherry, k=2"),
-    ]
+    ],
 )
 def test_similarity_search_valid(query, k, expected):
     if k is None:
@@ -70,7 +70,7 @@ def test_similarity_search_valid(query, k, expected):
     [
         ("orange", 0),
         ("mango", -1),
-    ]
+    ],
 )
 def test_similarity_search_invalid(query, k):
     with pytest.raises(ValueError, match="must be an integer greater than 0"):
@@ -88,7 +88,7 @@ def dummy_max_marginal_relevance_search(query, k=4, fetch_k=10):
         ("apple", None, None, "Query: apple, k=4, fetch_k=10"),
         ("banana", 3, 5, "Query: banana, k=3, fetch_k=5"),
         ("cherry", 2, 2, "Query: cherry, k=2, fetch_k=2"),
-    ]
+    ],
 )
 def test_max_marginal_relevance_search_valid(query, k, fetch_k, expected):
     if k is None and fetch_k is None:
@@ -106,7 +106,7 @@ def test_max_marginal_relevance_search_valid(query, k, fetch_k, expected):
         ("orange", 0, 5, "must be an integer greater than 0"),
         ("mango", -1, 5, "must be an integer greater than 0"),
         ("grape", 5, 3, "greater than or equal to 'k'"),
-    ]
+    ],
 )
 def test_max_marginal_relevance_search_invalid(query, k, fetch_k, match):
     with pytest.raises(ValueError, match=match):

--- a/tests/unit_tests/test_vectorstores.py
+++ b/tests/unit_tests/test_vectorstores.py
@@ -1,5 +1,7 @@
 """Test HanaVector functionality."""
 
+import pytest
+
 from langchain_hana.vectorstores import HanaDB
 
 
@@ -39,6 +41,73 @@ def test_int_sanitation_with_illegal_negative_value() -> None:
         pass
 
     assert successful
+
+
+@HanaDB._validate_k
+def dummy_similarity_search(query, k=4):
+    return f"Query: {query}, k={k}"
+
+
+def test_similarity_search_valid_defaults():
+    assert dummy_similarity_search("apple") == "Query: apple, k=4"
+
+
+def test_similarity_search_valid_positional():
+    assert dummy_similarity_search("banana", 3) == "Query: banana, k=3"
+
+
+def test_similarity_search_valid_keyword():
+    assert dummy_similarity_search("cherry", k=2) == "Query: cherry, k=2"
+
+
+def test_similarity_search_invalid_k_zero():
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        dummy_similarity_search("orange", k=0)
+
+
+def test_similarity_search_invalid_k_negative():
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        dummy_similarity_search("mango", k=-1)
+
+
+@HanaDB._validate_k_and_fetch_k
+def dummy_max_marginal_relevance_search(query, k=4, fetch_k=10):
+    return f"Query: {query}, k={k}, fetch_k={fetch_k}"
+
+
+def test_max_marginal_relevance_search_valid_defaults():
+    assert (
+        dummy_max_marginal_relevance_search("apple") == "Query: apple, k=4, fetch_k=10"
+    )
+
+
+def test_max_marginal_relevance_search_valid_positional():
+    assert (
+        dummy_max_marginal_relevance_search("banana", 3, 5)
+        == "Query: banana, k=3, fetch_k=5"
+    )
+
+
+def test_max_marginal_relevance_search_valid_keyword():
+    assert (
+        dummy_max_marginal_relevance_search("cherry", k=2, fetch_k=2)
+        == "Query: cherry, k=2, fetch_k=2"
+    )
+
+
+def test_max_marginal_relevance_search_invalid_k_zero():
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        dummy_max_marginal_relevance_search("orange", k=0, fetch_k=5)
+
+
+def test_max_marginal_relevance_search_invalid_k_negative():
+    with pytest.raises(ValueError, match="must be an integer greater than 0"):
+        dummy_max_marginal_relevance_search("mango", k=-1, fetch_k=5)
+
+
+def test_max_marginal_relevance_search_invalid_fetch_k_less_than_k():
+    with pytest.raises(ValueError, match="greater than or equal to 'k'"):
+        dummy_max_marginal_relevance_search("grape", k=5, fetch_k=3)
 
 
 def test_parse_float_array_from_string() -> None:

--- a/tests/unit_tests/test_vectorstores.py
+++ b/tests/unit_tests/test_vectorstores.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from langchain_hana.utils import _validate_k, _validate_k_and_fetch_k
 from langchain_hana.vectorstores import HanaDB
 
 
@@ -43,71 +44,73 @@ def test_int_sanitation_with_illegal_negative_value() -> None:
     assert successful
 
 
-@HanaDB._validate_k
 def dummy_similarity_search(query, k=4):
+    _validate_k(k)
     return f"Query: {query}, k={k}"
 
 
-def test_similarity_search_valid_defaults():
-    assert dummy_similarity_search("apple") == "Query: apple, k=4"
+@pytest.mark.parametrize(
+    "query, k, expected",
+    [
+        ("apple", None, "Query: apple, k=4"),
+        ("banana", 3, "Query: banana, k=3"),
+        ("cherry", 2, "Query: cherry, k=2"),
+    ]
+)
+def test_similarity_search_valid(query, k, expected):
+    if k is None:
+        result = dummy_similarity_search(query)
+    else:
+        result = dummy_similarity_search(query, k)
+    assert result == expected
 
 
-def test_similarity_search_valid_positional():
-    assert dummy_similarity_search("banana", 3) == "Query: banana, k=3"
-
-
-def test_similarity_search_valid_keyword():
-    assert dummy_similarity_search("cherry", k=2) == "Query: cherry, k=2"
-
-
-def test_similarity_search_invalid_k_zero():
+@pytest.mark.parametrize(
+    "query, k",
+    [
+        ("orange", 0),
+        ("mango", -1),
+    ]
+)
+def test_similarity_search_invalid(query, k):
     with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        dummy_similarity_search("orange", k=0)
+        dummy_similarity_search(query, k=k)
 
 
-def test_similarity_search_invalid_k_negative():
-    with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        dummy_similarity_search("mango", k=-1)
-
-
-@HanaDB._validate_k_and_fetch_k
 def dummy_max_marginal_relevance_search(query, k=4, fetch_k=10):
+    _validate_k_and_fetch_k(k, fetch_k)
     return f"Query: {query}, k={k}, fetch_k={fetch_k}"
 
 
-def test_max_marginal_relevance_search_valid_defaults():
-    assert (
-        dummy_max_marginal_relevance_search("apple") == "Query: apple, k=4, fetch_k=10"
-    )
+@pytest.mark.parametrize(
+    "query, k, fetch_k, expected",
+    [
+        ("apple", None, None, "Query: apple, k=4, fetch_k=10"),
+        ("banana", 3, 5, "Query: banana, k=3, fetch_k=5"),
+        ("cherry", 2, 2, "Query: cherry, k=2, fetch_k=2"),
+    ]
+)
+def test_max_marginal_relevance_search_valid(query, k, fetch_k, expected):
+    if k is None and fetch_k is None:
+        result = dummy_max_marginal_relevance_search(query)
+    elif fetch_k is None:
+        result = dummy_max_marginal_relevance_search(query, k)
+    else:
+        result = dummy_max_marginal_relevance_search(query, k, fetch_k)
+    assert result == expected
 
 
-def test_max_marginal_relevance_search_valid_positional():
-    assert (
-        dummy_max_marginal_relevance_search("banana", 3, 5)
-        == "Query: banana, k=3, fetch_k=5"
-    )
-
-
-def test_max_marginal_relevance_search_valid_keyword():
-    assert (
-        dummy_max_marginal_relevance_search("cherry", k=2, fetch_k=2)
-        == "Query: cherry, k=2, fetch_k=2"
-    )
-
-
-def test_max_marginal_relevance_search_invalid_k_zero():
-    with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        dummy_max_marginal_relevance_search("orange", k=0, fetch_k=5)
-
-
-def test_max_marginal_relevance_search_invalid_k_negative():
-    with pytest.raises(ValueError, match="must be an integer greater than 0"):
-        dummy_max_marginal_relevance_search("mango", k=-1, fetch_k=5)
-
-
-def test_max_marginal_relevance_search_invalid_fetch_k_less_than_k():
-    with pytest.raises(ValueError, match="greater than or equal to 'k'"):
-        dummy_max_marginal_relevance_search("grape", k=5, fetch_k=3)
+@pytest.mark.parametrize(
+    "query, k, fetch_k, match",
+    [
+        ("orange", 0, 5, "must be an integer greater than 0"),
+        ("mango", -1, 5, "must be an integer greater than 0"),
+        ("grape", 5, 3, "greater than or equal to 'k'"),
+    ]
+)
+def test_max_marginal_relevance_search_invalid(query, k, fetch_k, match):
+    with pytest.raises(ValueError, match=match):
+        dummy_max_marginal_relevance_search(query, k=k, fetch_k=fetch_k)
 
 
 def test_parse_float_array_from_string() -> None:


### PR DESCRIPTION
This adds the checks for `k` and `fetch_k `in similarity and MMR search functions.
For similarity search, `k > 0` condition is checked and error is reported when `k <= 0`.
For MMR search, `k > 0 && fetch_k >= k` are checked and an error is reported otherwise.

Test cases are also added for the same in the integration_tests and tests directory.
