### PR TITLE
Prevent querying all the available graphs when DEFAULT graph is the graph_uri

### DIFF
--- a/tests/integration_tests/test_graphs.py
+++ b/tests/integration_tests/test_graphs.py
@@ -130,14 +130,14 @@ def test_hana_rdf_default_graph_creation_with_graph_uri(default_graph_with_graph
 
     assert default_graph_with_graph_uri
     assert isinstance(default_graph_with_graph_uri, HanaRdfGraph)
-    assert default_graph_with_graph_uri.graph_uri == "DEFAULT"
+    assert default_graph_with_graph_uri.from_clause == "FROM DEFAULT"
 
 def test_hana_rdf_graph_creation_with_graph_uri(example_graph):
     """Test graph creation with graph URI."""
 
     assert example_graph
     assert isinstance(example_graph, HanaRdfGraph)
-    assert example_graph.graph_uri == "http://example.com/graph"
+    assert example_graph.from_clause == "FROM <http://example.com/graph>"
 
 def test_hana_rdf_graph_creation_with_ontology_uri(ontology_graph):
     """Test graph creation with ontology URI."""


### PR DESCRIPTION
This PR reverts some changes from #33 as HANA SPARQL queries all graphs when the `FROM` Clause is not present.
We removed the FROM Clause whenever the graph_uri was in ("", None, "DEFAULT"), resulting in the query being executed over all the present graphs. This is specific to HANA's SPARQL behaviour.

At present, we should support the `DEFAULT` graph as the default value of the `graph_uri` parameter.

The `graph.query()` calls, where the `inject_from_clause` is set to `True` now handles the addition of appropriate `FROM` Clauses, thus directing the queries to the appropriate graphs.
Executing a query without providing a from clause and without setting the `inject_from_clause` flag, would still result in the query being run over all available graphs in the db instance.
The auto extraction of ontology, also now handles the appropriate `FROM` clause and only queries the `graph_uri` specified.

In the future, we would add the support of specifying a value of `graph_uri` which would result in the query being executed across all the available graphs.