### PR TITLE
Change schema member attribute to rdflib.Graph instead of a string

### DIFF
--- a/langchain_hana/graphs/hana_rdf_graph.py
+++ b/langchain_hana/graphs/hana_rdf_graph.py
@@ -255,7 +255,7 @@ class HanaRdfGraph:
                 ontology_query
             )
 
-        self.schema = ontology_schema_graph.serialize(format="turtle")
+        self.schema = ontology_schema_graph
 
     @staticmethod
     def _validate_construct_query(construct_query: str) -> None:


### PR DESCRIPTION
This PR changes the datatype of the member attribute `schema` for the `HanaRdfGraph` class.
This adds the following benefits -

1. Repeated serialization is avoided. When creating the ontology graph from a given user query, the Response given by the Query from the HANA SPARQL server, is the schema in the from of a `string`. Earlier, we parse the string into a `rdflib.graph` instance and then serialize it again, using the rdflib's inbuilt serializer.
=> Now, we only parse the graph into a `rdflib.graph` instance and return that instance to populate our `schema` member attribute.

2. Graph serialization is `unordered`. Serializing tuples can generate any order while creating a string. This creates a problem while writing test cases. The same behavior is also replicated in the TS equivalent package.
=> To avoid this, we need to compare graph instances, instead of strings for checking the correct functionality.

3. Added benefits of comparing, querying when having `schema` as a `rdflib.Graph` instance is inherent.

Apart from this main change, this also refactors some code in the `integration_tests/test_graphs.py` to make the fixtures more verbose.