### PR TITLE
enh: enable insertion of documents using map merge sql approach

### DIFF
--- a/examples/sap_hanavector.ipynb
+++ b/examples/sap_hanavector.ipynb
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -182,7 +182,11 @@
     "from langchain_core.documents import Document\n",
     "\n",
     "docs = [Document(page_content=\"Some text\"), Document(page_content=\"Other docs\")]\n",
-    "db.add_documents(docs)"
+    "db.add_documents(docs)\n",
+    "\n",
+    "# a use_map_merge flag can be supplied for faster insertion\n",
+    "# map merge only works with internal embeddings\n",
+    "# db.add_documents(docs, use_map_merge=True)"
    ]
   },
   {

--- a/examples/sap_hanavector.ipynb
+++ b/examples/sap_hanavector.ipynb
@@ -185,6 +185,7 @@
     "db.add_documents(docs)\n",
     "\n",
     "# a use_map_merge flag can be supplied for faster insertion\n",
+    "# use_map_merge is only accepted as a keyword argument\n",
     "# map merge only works with internal embeddings\n",
     "# db.add_documents(docs, use_map_merge=True)"
    ]

--- a/langchain_hana/vectorstores/hana_db.py
+++ b/langchain_hana/vectorstores/hana_db.py
@@ -795,8 +795,6 @@ class HanaDB(VectorStore):
         # Insert data into the table
         cur = self.connection.cursor()
         try:
-            print(sql_str)
-            print(sql_params)
             cur.executemany(sql_str, sql_params)
         finally:
             cur.close()

--- a/langchain_hana/vectorstores/hana_db.py
+++ b/langchain_hana/vectorstores/hana_db.py
@@ -563,7 +563,7 @@ class HanaDB(VectorStore):
         if self.use_internal_embeddings:
             if use_map_merge:
                 return self._add_texts_with_map_merge_using_internal_embedding(
-                    texts, metadatas, embeddings
+                    texts, metadatas
                 )
             return self._add_texts_using_internal_embedding(
                 texts, metadatas, embeddings
@@ -674,7 +674,6 @@ class HanaDB(VectorStore):
         self,
         texts: Iterable[str],
         metadatas: Optional[list[dict]] = None,
-        embeddings: Optional[list[list[float]]] = None,
         **kwargs: Any,
     ) -> list[str]:
         """Add texts with map merge insertion using internal embedding function"""
@@ -692,20 +691,16 @@ class HanaDB(VectorStore):
         '''
 
         try:
-            try:
-                cur.execute(create_temp_table_sql)
-            except Exception as e:
-                raise Exception(f"Error while creating temporary table for map merge :{e}")
-            
+            cur.execute(create_temp_table_sql)
+        except Exception as e:
+            raise Exception(f"Error while creating temporary table for map merge :{e}")
+
+        try:
             insert_temp_table_sql = f'''
             INSERT INTO {temp_table_name} (ID, "VEC_TEXT", "VEC_VECTOR")
             VALUES (?,?,NULL)
             '''
-
-            try:
-                cur.executemany(insert_temp_table_sql, [(i, text) for i,text in enumerate(texts)])
-            except Exception as e:
-                raise Exception(f"Error while inserting rows into temporary table for map merge :{e}")
+            cur.executemany(insert_temp_table_sql, [(i, text) for i,text in enumerate(texts)])
             
             if self.internal_embedding_remote_source:
                 vector_embedding_sql = f"""VECTOR_EMBEDDING(:i_text, 'DOCUMENT', '{self.internal_embedding_model_id}', "{self.internal_embedding_remote_source}")"""
@@ -733,10 +728,7 @@ class HanaDB(VectorStore):
             """
             
             try:
-                try:
-                    cur.execute(create_map_merge_function_sql)
-                except Exception as e:
-                    raise Exception(f"Error while creating map merge function :{e}")
+                cur.execute(create_map_merge_function_sql)
                 
                 call_map_merge_sql = f"""
                     DO()
@@ -751,30 +743,18 @@ class HanaDB(VectorStore):
                     END;
                 """
 
-                try:
-                    cur.execute(call_map_merge_sql)
-                except Exception as e:
-                    raise Exception(f"Error while calling map merge function: {e}")
+                cur.execute(call_map_merge_sql)
 
                 fetch_embeddings_sql = f"""
                 SELECT VEC_VECTOR FROM {temp_table_name}
                 """
-                try:
-                    cur.execute(fetch_embeddings_sql)
-                    rows = cur.fetchall()
-                    embeddings = [row[0] for row in rows]
-                except Exception as e:
-                    raise Exception(f"Error while fetching embeddings: {e}")     
+                cur.execute(fetch_embeddings_sql)
+                rows = cur.fetchall()
+                embeddings = [row[0] for row in rows]
             finally:
-                try:
-                    cur.execute(f"DROP FUNCTION {temp_func_name}")
-                except Exception as e:
-                    raise Exception(f"Error while dropping map merge function: {e}")
+                cur.execute(f"DROP FUNCTION {temp_func_name}")
         finally:
-            try:
-                cur.execute(f"DROP TABLE {temp_table_name}")
-            except Exception as e:
-                raise Exception(f"Error while dropping temp table: {e}")
+            cur.execute(f"DROP TABLE {temp_table_name}")
 
         sql_params = []
         for i, text in enumerate(texts):
@@ -804,7 +784,6 @@ class HanaDB(VectorStore):
         )
 
         # Insert data into the table
-        cur = self.connection.cursor()
         try:
             cur.executemany(sql_str, sql_params)
         finally:

--- a/langchain_hana/vectorstores/hana_db.py
+++ b/langchain_hana/vectorstores/hana_db.py
@@ -14,6 +14,7 @@ from typing import (
     Pattern,
     Type,
 )
+import uuid
 
 import numpy as np
 from hdbcli import dbapi  # type: ignore
@@ -678,7 +679,7 @@ class HanaDB(VectorStore):
         cur = self.connection.cursor()
 
         create_temp_table_sql = f'''
-        CREATE TABLE {self.table_name}_TEMP (
+        CREATE TEMPORARY TABLE #{self.table_name}_TEMP (
             ID INT PRIMARY KEY,
             "VEC_TEXT" NCLOB,
             "VEC_VECTOR" {self.vector_column_type}
@@ -686,84 +687,88 @@ class HanaDB(VectorStore):
         '''
 
         try:
-            cur.execute(create_temp_table_sql)
-        except Exception as e:
-            raise Exception(f"Error while creating table for map merge :{e}")
-        
-        insert_temp_table_sql = f'''
-        INSERT INTO {self.table_name}_TEMP (ID, "VEC_TEXT", "VEC_VECTOR")
-        VALUES (?,?,NULL)
-        '''
+            try:
+                cur.execute(create_temp_table_sql)
+            except Exception as e:
+                raise Exception(f"Error while creating temporary table for map merge :{e}")
+            
+            insert_temp_table_sql = f'''
+            INSERT INTO #{self.table_name}_TEMP (ID, "VEC_TEXT", "VEC_VECTOR")
+            VALUES (?,?,NULL)
+            '''
 
-        try:
-            cur.executemany(insert_temp_table_sql, [(i, text) for i,text in enumerate(texts)])
-        except Exception as e:
-            raise Exception(f"Error while inserting rows for map merge :{e}")
-        
-        if self.internal_embedding_remote_source:
-            vector_embedding_sql = f"""VECTOR_EMBEDDING(:i_text, 'DOCUMENT', '{self.internal_embedding_model_id}', "{self.internal_embedding_remote_source}")"""
-        else:
-            vector_embedding_sql = f"""VECTOR_EMBEDDING(:i_text, 'DOCUMENT', '{self.internal_embedding_model_id}')"""
-        vector_embedding_sql = self._convert_vector_embedding_to_column_type(
-            vector_embedding_sql
-        )
-        
-        create_map_merge_function_sql = f"""
-        CREATE OR REPLACE FUNCTION F_VECTOR_EMBEDDING(
-                IN i_id INT,
-                IN i_text NCLOB
+            try:
+                cur.executemany(insert_temp_table_sql, [(i, text) for i,text in enumerate(texts)])
+            except Exception as e:
+                raise Exception(f"Error while inserting rows into temporary table for map merge :{e}")
+            
+            if self.internal_embedding_remote_source:
+                vector_embedding_sql = f"""VECTOR_EMBEDDING(:i_text, 'DOCUMENT', '{self.internal_embedding_model_id}', "{self.internal_embedding_remote_source}")"""
+            else:
+                vector_embedding_sql = f"""VECTOR_EMBEDDING(:i_text, 'DOCUMENT', '{self.internal_embedding_model_id}')"""
+            vector_embedding_sql = self._convert_vector_embedding_to_column_type(
+                vector_embedding_sql
             )
-            RETURNS TABLE("ID" INT, "PAL_EMBEDDING" {self.vector_column_type})
-            LANGUAGE SQLSCRIPT READS SQL DATA AS
-            BEGIN
-                RETURN 
-                    SELECT :i_id AS "ID", 
-                        {vector_embedding_sql} AS "PAL_EMBEDDING"
-                    FROM DUMMY;
-            END;
-         """
-        
-        try:
-            cur.execute(create_map_merge_function_sql)
-        except Exception as e:
-            raise Exception(f"Error while creating map merge function :{e}")
-        
-        call_map_merge_sql = f"""
-            DO()
-            BEGIN
-                dat = SELECT "ID", "VEC_TEXT", "VEC_VECTOR" FROM "{self.table_name}_TEMP";
-                o_res = MAP_MERGE(:dat, "F_VECTOR_EMBEDDING"(:dat."ID", :dat."VEC_TEXT"));
-                MERGE INTO "{self.table_name}_TEMP" AS dat
-                USING :o_res AS upd
-                ON dat."ID" = upd."ID"
-                WHEN MATCHED THEN
-                    UPDATE SET dat."VEC_VECTOR" = upd."PAL_EMBEDDING";
-            END;
-        """
+            
+            uid = str(uuid.uuid4())
+            create_map_merge_function_sql = f"""
+            CREATE OR REPLACE FUNCTION F_VECTOR_EMBEDDING_{uid}(
+                    IN i_id INT,
+                    IN i_text NCLOB
+                )
+                RETURNS TABLE("ID" INT, "PAL_EMBEDDING" {self.vector_column_type})
+                LANGUAGE SQLSCRIPT READS SQL DATA AS
+                BEGIN
+                    RETURN 
+                        SELECT :i_id AS "ID", 
+                            {vector_embedding_sql} AS "PAL_EMBEDDING"
+                        FROM DUMMY;
+                END;
+            """
+            
+            try:
+                try:
+                    cur.execute(create_map_merge_function_sql)
+                except Exception as e:
+                    raise Exception(f"Error while creating map merge function :{e}")
+                
+                call_map_merge_sql = f"""
+                    DO()
+                    BEGIN
+                        dat = SELECT "ID", "VEC_TEXT", "VEC_VECTOR" FROM "{self.table_name}_TEMP";
+                        o_res = MAP_MERGE(:dat, "F_VECTOR_EMBEDDING"(:dat."ID", :dat."VEC_TEXT"));
+                        MERGE INTO "{self.table_name}_TEMP" AS dat
+                        USING :o_res AS upd
+                        ON dat."ID" = upd."ID"
+                        WHEN MATCHED THEN
+                            UPDATE SET dat."VEC_VECTOR" = upd."PAL_EMBEDDING";
+                    END;
+                """
 
-        try:
-            cur.execute(call_map_merge_sql)
-        except Exception as e:
-            raise Exception(f"Error while calling map merge function :{e}")
-        
+                try:
+                    cur.execute(call_map_merge_sql)
+                except Exception as e:
+                    raise Exception(f"Error while calling map merge function :{e}")
 
-        fetch_embeddings_sql = f"""
-        SELECT VEC_VECTOR FROM {self.table_name}_TEMP
-        """
-        try:
-            cur.execute(fetch_embeddings_sql)
-            rows = cur.fetchall()
-            embeddings = [row[0] for row in rows]
-        except Exception as e:
-            raise Exception(f"Error while fetching embeddings :{e}")
-        
-
-        try:
-            cur.execute(f"DROP FUNCTION F_VECTOR_EMBEDDING")
-            cur.execute(f"DROP TABLE {self.table_name}_TEMP")
-        except Exception as e:
-            raise Exception(f"Error while dropping temp table/function :{e}")
-
+                fetch_embeddings_sql = f"""
+                SELECT VEC_VECTOR FROM {self.table_name}_TEMP
+                """
+                try:
+                    cur.execute(fetch_embeddings_sql)
+                    rows = cur.fetchall()
+                    embeddings = [row[0] for row in rows]
+                except Exception as e:
+                    raise Exception(f"Error while fetching embeddings :{e}")     
+            finally:
+                try:
+                    cur.execute(f"DROP FUNCTION F_VECTOR_EMBEDDING_{uid}")
+                except Exception as e:
+                    raise Exception(f"Error while dropping map merge function :{e}")
+        finally:
+            try:
+                cur.execute(f"DROP TABLE {self.table_name}_TEMP")
+            except Exception as e:
+                raise Exception(f"Error while dropping temp table/function :{e}")
 
         sql_params = []
         for i, text in enumerate(texts):

--- a/langchain_hana/vectorstores/hana_db.py
+++ b/langchain_hana/vectorstores/hana_db.py
@@ -539,6 +539,7 @@ class HanaDB(VectorStore):
         texts: Iterable[str],
         metadatas: Optional[list[dict]] = None,
         embeddings: Optional[list[list[float]]] = None,
+        *,
         use_map_merge: bool = False,
         **kwargs: Any,
     ) -> list[str]:
@@ -550,6 +551,8 @@ class HanaDB(VectorStore):
                 Defaults to None.
             embeddings (Optional[list[list[float]]], optional): Optional pre-generated
                 embeddings. Defaults to None.
+            use_map_merge (bool, optional): Whether to use map merge for insertion
+                when using internal embeddings. Defaults to False.
 
         Returns:
             list[str]: empty list
@@ -679,9 +682,10 @@ class HanaDB(VectorStore):
         cur = self.connection.cursor()
 
         temp_table_name = f"#{self.table_name}_TEMP"
+        # TEMP TABLES ARE ROW BASED BY DEFAULT
         create_temp_table_sql = f'''
-        CREATE LOCAL TEMPORARY TABLE {temp_table_name} (
-            ID INT PRIMARY KEY,
+        CREATE LOCAL TEMPORARY COLUMN TABLE {temp_table_name} (
+            ID INT,
             "VEC_TEXT" NCLOB,
             "VEC_VECTOR" {self.vector_column_type}
         )
@@ -711,9 +715,10 @@ class HanaDB(VectorStore):
                 vector_embedding_sql
             )
             
-            uid = str(uuid.uuid4())
+            uid = str(uuid.uuid4()).replace("-", "_")
+            temp_func_name = f"F_VECTOR_EMBEDDING_{uid}"
             create_map_merge_function_sql = f"""
-            CREATE OR REPLACE FUNCTION F_VECTOR_EMBEDDING_{uid}(
+            CREATE OR REPLACE FUNCTION {temp_func_name}(
                     IN i_id INT,
                     IN i_text NCLOB
                 )
@@ -736,9 +741,9 @@ class HanaDB(VectorStore):
                 call_map_merge_sql = f"""
                     DO()
                     BEGIN
-                        dat = SELECT "ID", "VEC_TEXT", "VEC_VECTOR" FROM "{temp_table_name}";
-                        o_res = MAP_MERGE(:dat, "F_VECTOR_EMBEDDING_{uid}"(:dat."ID", :dat."VEC_TEXT"));
-                        MERGE INTO "{temp_table_name}" AS dat
+                        dat = SELECT "ID", "VEC_TEXT", "VEC_VECTOR" FROM {temp_table_name};
+                        o_res = MAP_MERGE(:dat, {temp_func_name}(:dat."ID", :dat."VEC_TEXT"));
+                        MERGE INTO {temp_table_name} AS dat
                         USING :o_res AS upd
                         ON dat."ID" = upd."ID"
                         WHEN MATCHED THEN
@@ -752,7 +757,7 @@ class HanaDB(VectorStore):
                     raise Exception(f"Error while calling map merge function: {e}")
 
                 fetch_embeddings_sql = f"""
-                SELECT VEC_VECTOR FROM "{temp_table_name}"
+                SELECT VEC_VECTOR FROM {temp_table_name}
                 """
                 try:
                     cur.execute(fetch_embeddings_sql)
@@ -762,7 +767,7 @@ class HanaDB(VectorStore):
                     raise Exception(f"Error while fetching embeddings: {e}")     
             finally:
                 try:
-                    cur.execute(f"DROP FUNCTION F_VECTOR_EMBEDDING_{uid}")
+                    cur.execute(f"DROP FUNCTION {temp_func_name}")
                 except Exception as e:
                     raise Exception(f"Error while dropping map merge function: {e}")
         finally:
@@ -830,8 +835,8 @@ class HanaDB(VectorStore):
         vector_column: str = default_vector_column,
         vector_column_length: int = default_vector_column_length,
         vector_column_type: str = default_vector_column_type,
-        use_map_merge: bool = False,
         *,
+        use_map_merge: bool = False,
         specific_metadata_columns: Optional[list[str]] = None,
     ):
         """Create a HanaDB instance from raw documents.

--- a/langchain_hana/vectorstores/hana_db.py
+++ b/langchain_hana/vectorstores/hana_db.py
@@ -678,8 +678,9 @@ class HanaDB(VectorStore):
 
         cur = self.connection.cursor()
 
+        temp_table_name = f"#{self.table_name}_TEMP"
         create_temp_table_sql = f'''
-        CREATE TEMPORARY TABLE #{self.table_name}_TEMP (
+        CREATE LOCAL TEMPORARY TABLE {temp_table_name} (
             ID INT PRIMARY KEY,
             "VEC_TEXT" NCLOB,
             "VEC_VECTOR" {self.vector_column_type}
@@ -693,7 +694,7 @@ class HanaDB(VectorStore):
                 raise Exception(f"Error while creating temporary table for map merge :{e}")
             
             insert_temp_table_sql = f'''
-            INSERT INTO #{self.table_name}_TEMP (ID, "VEC_TEXT", "VEC_VECTOR")
+            INSERT INTO {temp_table_name} (ID, "VEC_TEXT", "VEC_VECTOR")
             VALUES (?,?,NULL)
             '''
 
@@ -735,9 +736,9 @@ class HanaDB(VectorStore):
                 call_map_merge_sql = f"""
                     DO()
                     BEGIN
-                        dat = SELECT "ID", "VEC_TEXT", "VEC_VECTOR" FROM "{self.table_name}_TEMP";
-                        o_res = MAP_MERGE(:dat, "F_VECTOR_EMBEDDING"(:dat."ID", :dat."VEC_TEXT"));
-                        MERGE INTO "{self.table_name}_TEMP" AS dat
+                        dat = SELECT "ID", "VEC_TEXT", "VEC_VECTOR" FROM "{temp_table_name}";
+                        o_res = MAP_MERGE(:dat, "F_VECTOR_EMBEDDING_{uid}"(:dat."ID", :dat."VEC_TEXT"));
+                        MERGE INTO "{temp_table_name}" AS dat
                         USING :o_res AS upd
                         ON dat."ID" = upd."ID"
                         WHEN MATCHED THEN
@@ -748,27 +749,27 @@ class HanaDB(VectorStore):
                 try:
                     cur.execute(call_map_merge_sql)
                 except Exception as e:
-                    raise Exception(f"Error while calling map merge function :{e}")
+                    raise Exception(f"Error while calling map merge function: {e}")
 
                 fetch_embeddings_sql = f"""
-                SELECT VEC_VECTOR FROM {self.table_name}_TEMP
+                SELECT VEC_VECTOR FROM "{temp_table_name}"
                 """
                 try:
                     cur.execute(fetch_embeddings_sql)
                     rows = cur.fetchall()
                     embeddings = [row[0] for row in rows]
                 except Exception as e:
-                    raise Exception(f"Error while fetching embeddings :{e}")     
+                    raise Exception(f"Error while fetching embeddings: {e}")     
             finally:
                 try:
                     cur.execute(f"DROP FUNCTION F_VECTOR_EMBEDDING_{uid}")
                 except Exception as e:
-                    raise Exception(f"Error while dropping map merge function :{e}")
+                    raise Exception(f"Error while dropping map merge function: {e}")
         finally:
             try:
-                cur.execute(f"DROP TABLE {self.table_name}_TEMP")
+                cur.execute(f"DROP TABLE {temp_table_name}")
             except Exception as e:
-                raise Exception(f"Error while dropping temp table/function :{e}")
+                raise Exception(f"Error while dropping temp table: {e}")
 
         sql_params = []
         for i, text in enumerate(texts):

--- a/langchain_hana/vectorstores/hana_db.py
+++ b/langchain_hana/vectorstores/hana_db.py
@@ -538,6 +538,7 @@ class HanaDB(VectorStore):
         texts: Iterable[str],
         metadatas: Optional[list[dict]] = None,
         embeddings: Optional[list[list[float]]] = None,
+        use_map_merge: bool = False,
         **kwargs: Any,
     ) -> list[str]:
         """Add texts to the vectorstore.
@@ -556,10 +557,16 @@ class HanaDB(VectorStore):
         # decide how to add texts
         # using external embedding instance or internal embedding function of HanaDB
         if self.use_internal_embeddings:
+            if use_map_merge:
+                return self._add_texts_with_map_merge_using_internal_embedding(
+                    texts, metadatas, embeddings
+                )
             return self._add_texts_using_internal_embedding(
                 texts, metadatas, embeddings
             )
         else:
+            if use_map_merge:
+                raise ValueError("map merge cannot be used with external embeddings")
             return self._add_texts_using_external_embedding(
                 texts, metadatas, embeddings
             )
@@ -659,6 +666,142 @@ class HanaDB(VectorStore):
             cur.close()
         return []
 
+    def _add_texts_with_map_merge_using_internal_embedding(
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[list[dict]] = None,
+        embeddings: Optional[list[list[float]]] = None,
+        **kwargs: Any,
+    ) -> list[str]:
+        """Add texts with map merge insertion using internal embedding function"""
+
+        cur = self.connection.cursor()
+
+        create_temp_table_sql = f'''
+        CREATE TABLE {self.table_name}_TEMP (
+            ID INT PRIMARY KEY,
+            "VEC_TEXT" NCLOB,
+            "VEC_VECTOR" {self.vector_column_type}
+        )
+        '''
+
+        try:
+            cur.execute(create_temp_table_sql)
+        except Exception as e:
+            raise Exception(f"Error while creating table for map merge :{e}")
+        
+        insert_temp_table_sql = f'''
+        INSERT INTO {self.table_name}_TEMP (ID, "VEC_TEXT", "VEC_VECTOR")
+        VALUES (?,?,NULL)
+        '''
+
+        try:
+            cur.executemany(insert_temp_table_sql, [(i, text) for i,text in enumerate(texts)])
+        except Exception as e:
+            raise Exception(f"Error while inserting rows for map merge :{e}")
+        
+        if self.internal_embedding_remote_source:
+            vector_embedding_sql = f"""VECTOR_EMBEDDING(:i_text, 'DOCUMENT', '{self.internal_embedding_model_id}', "{self.internal_embedding_remote_source}")"""
+        else:
+            vector_embedding_sql = f"""VECTOR_EMBEDDING(:i_text, 'DOCUMENT', '{self.internal_embedding_model_id}')"""
+        vector_embedding_sql = self._convert_vector_embedding_to_column_type(
+            vector_embedding_sql
+        )
+        
+        create_map_merge_function_sql = f"""
+        CREATE OR REPLACE FUNCTION F_VECTOR_EMBEDDING(
+                IN i_id INT,
+                IN i_text NCLOB
+            )
+            RETURNS TABLE("ID" INT, "PAL_EMBEDDING" {self.vector_column_type})
+            LANGUAGE SQLSCRIPT READS SQL DATA AS
+            BEGIN
+                RETURN 
+                    SELECT :i_id AS "ID", 
+                        {vector_embedding_sql} AS "PAL_EMBEDDING"
+                    FROM DUMMY;
+            END;
+         """
+        
+        try:
+            cur.execute(create_map_merge_function_sql)
+        except Exception as e:
+            raise Exception(f"Error while creating map merge function :{e}")
+        
+        call_map_merge_sql = f"""
+            DO()
+            BEGIN
+                dat = SELECT "ID", "VEC_TEXT", "VEC_VECTOR" FROM "{self.table_name}_TEMP";
+                o_res = MAP_MERGE(:dat, "F_VECTOR_EMBEDDING"(:dat."ID", :dat."VEC_TEXT"));
+                MERGE INTO "{self.table_name}_TEMP" AS dat
+                USING :o_res AS upd
+                ON dat."ID" = upd."ID"
+                WHEN MATCHED THEN
+                    UPDATE SET dat."VEC_VECTOR" = upd."PAL_EMBEDDING";
+            END;
+        """
+
+        try:
+            cur.execute(call_map_merge_sql)
+        except Exception as e:
+            raise Exception(f"Error while calling map merge function :{e}")
+        
+
+        fetch_embeddings_sql = f"""
+        SELECT VEC_VECTOR FROM {self.table_name}_TEMP
+        """
+        try:
+            cur.execute(fetch_embeddings_sql)
+            rows = cur.fetchall()
+            embeddings = [row[0] for row in rows]
+        except Exception as e:
+            raise Exception(f"Error while fetching embeddings :{e}")
+        
+
+        try:
+            cur.execute(f"DROP FUNCTION F_VECTOR_EMBEDDING")
+            cur.execute(f"DROP TABLE {self.table_name}_TEMP")
+        except Exception as e:
+            raise Exception(f"Error while dropping temp table/function :{e}")
+
+
+        sql_params = []
+        for i, text in enumerate(texts):
+            metadata = metadatas[i] if metadatas else {}
+            metadata, extracted_special_metadata = self._split_off_special_metadata(
+                metadata
+            )
+            sql_params.append(
+                (
+                    text,
+                    json.dumps(
+                    HanaDB._sanitize_metadata_keys(metadata)
+                    ),
+                    embeddings[i],
+                    *extracted_special_metadata
+                )
+            )
+
+        specific_metadata_columns_string = self._get_specific_metadata_columns_string()
+
+        sql_str = (
+            f'INSERT INTO "{self.table_name}" ("{self.content_column}", '
+            f'"{self.metadata_column}", '
+            f'"{self.vector_column}"{specific_metadata_columns_string}) '
+            f"VALUES (?, ?, ? "
+            f"{(', ?'* len(self.specific_metadata_columns))});"
+        )
+
+        # Insert data into the table
+        cur = self.connection.cursor()
+        try:
+            print(sql_str)
+            print(sql_params)
+            cur.executemany(sql_str, sql_params)
+        finally:
+            cur.close()
+        return []
+
     def _get_specific_metadata_columns_string(self) -> str:
         """
         Helper function to generate the specific metadata columns as a SQL string.
@@ -683,6 +826,7 @@ class HanaDB(VectorStore):
         vector_column: str = default_vector_column,
         vector_column_length: int = default_vector_column_length,
         vector_column_type: str = default_vector_column_type,
+        use_map_merge: bool = False,
         *,
         specific_metadata_columns: Optional[list[str]] = None,
     ):
@@ -706,7 +850,7 @@ class HanaDB(VectorStore):
             vector_column_type=vector_column_type,
             specific_metadata_columns=specific_metadata_columns,
         )
-        instance.add_texts(texts, metadatas)
+        instance.add_texts(texts, metadatas, use_map_merge=use_map_merge)
         return instance
 
     def similarity_search(  # type: ignore[override]

--- a/tests/integration_tests/test_hana_db.py
+++ b/tests/integration_tests/test_hana_db.py
@@ -259,6 +259,12 @@ def test_hanavector_add_texts(vectorDB) -> None:
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
+def test_hanavector_add_texts_with_map_merge(vectorDB) -> None:
+    with pytest.raises(ValueError, match="map merge cannot be used with external embeddings"):
+        vectorDB.add_texts(texts=HanaTestConstants.TEXTS, use_map_merge=True)
+
+
+@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
 def test_hanavector_from_texts(table_name_with_cleanup) -> None:
     table_name = table_name_with_cleanup
     vectorDB = HanaDB.from_texts(
@@ -281,6 +287,19 @@ def test_hanavector_from_texts(table_name_with_cleanup) -> None:
         rows = cur.fetchall()
         number_of_rows = rows[0][0]
     assert number_of_rows == number_of_texts
+
+
+@pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")
+def test_hanavector_from_texts_with_map_merge(table_name_with_cleanup) -> None:
+    with pytest.raises(ValueError, match="map merge cannot be used with external embeddings"):
+        table_name = table_name_with_cleanup
+        vectorDB = HanaDB.from_texts(
+            connection=config.conn,
+            texts=HanaTestConstants.TEXTS,
+            embedding=embedding,
+            table_name=table_name,
+            use_map_merge=True,
+        )
 
 
 @pytest.mark.skipif(not hanadb_installed, reason="hanadb not installed")

--- a/tests/integration_tests/test_hana_db_internal_embeddings.py
+++ b/tests/integration_tests/test_hana_db_internal_embeddings.py
@@ -126,9 +126,10 @@ def table_name_with_cleanup():
     HanaTestUtils.drop_table(config.conn, HanaTestConstants.TABLE_NAME_CUSTOM_DB)
 
 
-def test_hanavector_add_texts(vectorDB) -> None:
+@pytest.mark.parametrize("use_map_merge", [False, True])
+def test_hanavector_add_texts(vectorDB, use_map_merge: bool) -> None:
     vectorDB.add_texts(
-        texts=HanaTestConstants.TEXTS, metadatas=HanaTestConstants.METADATAS
+        texts=HanaTestConstants.TEXTS, metadatas=HanaTestConstants.METADATAS, use_map_merge=use_map_merge
     )
 
     # check that embeddings have been created in the table
@@ -143,55 +144,15 @@ def test_hanavector_add_texts(vectorDB) -> None:
     assert number_of_rows == number_of_texts
 
 
-def test_hanavector_add_texts_with_map_merge(vectorDB) -> None:
-    vectorDB.add_texts(
-        texts=HanaTestConstants.TEXTS, metadatas=HanaTestConstants.METADATAS, use_map_merge=True
-    )
-
-    # check that embeddings have been created in the table
-    number_of_texts = len(HanaTestConstants.TEXTS)
-    number_of_rows = -1
-    sql_str = f"SELECT COUNT(*) FROM {HanaTestConstants.TABLE_NAME}"
-    cur = config.conn.cursor()
-    cur.execute(sql_str)
-    if cur.has_result_set():
-        rows = cur.fetchall()
-        number_of_rows = rows[0][0]
-    assert number_of_rows == number_of_texts
-
-
-def test_hanavector_from_texts(table_name_with_cleanup) -> None:
-    table_name = table_name_with_cleanup
-    vectorDB = HanaDB.from_texts(
-        connection=config.conn,
-        texts=HanaTestConstants.TEXTS,
-        embedding=config.embedding,
-        table_name=table_name
-    )
-
-    # test if vectorDB is instance of HanaDB
-    assert isinstance(vectorDB, HanaDB)
-
-    # check that embeddings have been created in the table
-    number_of_texts = len(HanaTestConstants.TEXTS)
-    number_of_rows = -1
-    sql_str = f"SELECT COUNT(*) FROM {table_name}"
-    cur = config.conn.cursor()
-    cur.execute(sql_str)
-    if cur.has_result_set():
-        rows = cur.fetchall()
-        number_of_rows = rows[0][0]
-    assert number_of_rows == number_of_texts
-
-
-def test_hanavector_from_texts_with_map_merge(table_name_with_cleanup) -> None:
+@pytest.mark.parametrize("use_map_merge", [False, True])
+def test_hanavector_from_texts(table_name_with_cleanup, use_map_merge: bool) -> None:
     table_name = table_name_with_cleanup
     vectorDB = HanaDB.from_texts(
         connection=config.conn,
         texts=HanaTestConstants.TEXTS,
         embedding=config.embedding,
         table_name=table_name,
-        use_map_merge=True
+        use_map_merge=use_map_merge
     )
 
     # test if vectorDB is instance of HanaDB
@@ -206,7 +167,7 @@ def test_hanavector_from_texts_with_map_merge(table_name_with_cleanup) -> None:
     if cur.has_result_set():
         rows = cur.fetchall()
         number_of_rows = rows[0][0]
-    assert number_of_rows == number_of_texts      
+    assert number_of_rows == number_of_texts    
 
 
 def test_hanavector_similarity_search_with_metadata_filter(

--- a/tests/integration_tests/test_hana_db_internal_embeddings.py
+++ b/tests/integration_tests/test_hana_db_internal_embeddings.py
@@ -120,6 +120,11 @@ def vectorDB(request):
 
     HanaTestUtils.drop_table(config.conn, HanaTestConstants.TABLE_NAME)
 
+@pytest.fixture
+def table_name_with_cleanup():
+    yield HanaTestConstants.TABLE_NAME_CUSTOM_DB
+    HanaTestUtils.drop_table(config.conn, HanaTestConstants.TABLE_NAME_CUSTOM_DB)
+
 
 def test_hanavector_add_texts(vectorDB) -> None:
     vectorDB.add_texts(
@@ -136,6 +141,72 @@ def test_hanavector_add_texts(vectorDB) -> None:
         rows = cur.fetchall()
         number_of_rows = rows[0][0]
     assert number_of_rows == number_of_texts
+
+
+def test_hanavector_add_texts_with_map_merge(vectorDB) -> None:
+    vectorDB.add_texts(
+        texts=HanaTestConstants.TEXTS, metadatas=HanaTestConstants.METADATAS, use_map_merge=True
+    )
+
+    # check that embeddings have been created in the table
+    number_of_texts = len(HanaTestConstants.TEXTS)
+    number_of_rows = -1
+    sql_str = f"SELECT COUNT(*) FROM {HanaTestConstants.TABLE_NAME}"
+    cur = config.conn.cursor()
+    cur.execute(sql_str)
+    if cur.has_result_set():
+        rows = cur.fetchall()
+        number_of_rows = rows[0][0]
+    assert number_of_rows == number_of_texts
+
+
+def test_hanavector_from_texts(table_name_with_cleanup) -> None:
+    table_name = table_name_with_cleanup
+    vectorDB = HanaDB.from_texts(
+        connection=config.conn,
+        texts=HanaTestConstants.TEXTS,
+        embedding=config.embedding,
+        table_name=table_name
+    )
+
+    # test if vectorDB is instance of HanaDB
+    assert isinstance(vectorDB, HanaDB)
+
+    # check that embeddings have been created in the table
+    number_of_texts = len(HanaTestConstants.TEXTS)
+    number_of_rows = -1
+    sql_str = f"SELECT COUNT(*) FROM {table_name}"
+    cur = config.conn.cursor()
+    cur.execute(sql_str)
+    if cur.has_result_set():
+        rows = cur.fetchall()
+        number_of_rows = rows[0][0]
+    assert number_of_rows == number_of_texts
+
+
+def test_hanavector_from_texts_with_map_merge(table_name_with_cleanup) -> None:
+    table_name = table_name_with_cleanup
+    vectorDB = HanaDB.from_texts(
+        connection=config.conn,
+        texts=HanaTestConstants.TEXTS,
+        embedding=config.embedding,
+        table_name=table_name,
+        use_map_merge=True
+    )
+
+    # test if vectorDB is instance of HanaDB
+    assert isinstance(vectorDB, HanaDB)
+
+    # check that embeddings have been created in the table
+    number_of_texts = len(HanaTestConstants.TEXTS)
+    number_of_rows = -1
+    sql_str = f"SELECT COUNT(*) FROM {table_name}"
+    cur = config.conn.cursor()
+    cur.execute(sql_str)
+    if cur.has_result_set():
+        rows = cur.fetchall()
+        number_of_rows = rows[0][0]
+    assert number_of_rows == number_of_texts      
 
 
 def test_hanavector_similarity_search_with_metadata_filter(


### PR DESCRIPTION
This PR adds the `use_map_merge` flag to functions `from_texts`, `add_texts`.
This flag only works when internal embeddings are used and raises an error otherwise.

Using this flag, documents are inserted into the vectorstore using the `map merge` method.

The corresponding test cases are also added to test the functionality.
Examples are also updated to depict this new functionality

Using this approach should result in 4-5x speedup while inserting large amount of documents in the vectorstore.

Update: 
=> The intermediate temp table creation is now done through a local temporary table which is unique for each connection object.
=> The map merge function identifier is now suffixed with a uuid4 (Random ID) which prevents parallel function creation conflicts by creating a unique identifier on each function call.


