### PR TITLE
chore: upgrade actions to latest versions

### DIFF
--- a/.github/actions/poetry_setup/action.yml
+++ b/.github/actions/poetry_setup/action.yml
@@ -26,13 +26,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       name: Setup python ${{ inputs.python-version }}
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       id: cache-bin-poetry
       name: Cache Poetry binary - Python ${{ inputs.python-version }}
       env:
@@ -55,7 +55,7 @@ runs:
         # Refresh the shell hashtable, to ensure correct `which` output.
         hash -r
 
-        # `actions/cache@v3` doesn't always seem able to correctly unpack softlinks.
+        # `actions/cache@v5` doesn't always seem able to correctly unpack softlinks.
         # Delete and recreate the softlinks pipx expects to have.
         rm /opt/pipx/venvs/poetry/bin/python
         cd /opt/pipx/venvs/poetry/bin
@@ -79,7 +79,7 @@ runs:
       run: pipx install "poetry==$POETRY_VERSION" --python '${{ steps.setup-python.outputs.python-path }}' --verbose
 
     - name: Restore pip and poetry cached dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MIN: "4"
         WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Python + Poetry ${{ env.PYTHON_VERSION }}
         uses: "./.github/actions/poetry_setup"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python + Poetry ${{ env.PYTHON_VERSION }}
         uses: "./.github/actions/poetry_setup"
@@ -51,7 +51,7 @@ jobs:
       version: ${{ steps.check-version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python + Poetry ${{ env.POETRY_VERSION }}
         uses: "./.github/actions/poetry_setup"
@@ -75,7 +75,7 @@ jobs:
         run: poetry build
 
       - name: Upload build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: ./dist/
@@ -103,7 +103,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
 
@@ -114,7 +114,7 @@ jobs:
           poetry-version: ${{ env.POETRY_VERSION }}
           cache-key: release
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: ./dist/
@@ -143,7 +143,7 @@ jobs:
         working-directory: .
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python + Poetry ${{ env.POETRY_VERSION }}
         uses: "./.github/actions/poetry_setup"
@@ -152,7 +152,7 @@ jobs:
           poetry-version: ${{ env.POETRY_VERSION }}
           cache-key: release
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/cache@v5download-artifact@v8
         with:
           name: dist
           path: ./dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
           poetry-version: ${{ env.POETRY_VERSION }}
           cache-key: release
 
-      - uses: actions/cache@v5download-artifact@v8
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: ./dist/


### PR DESCRIPTION
This PR upgrades the used github actions to their latest versions compatible with node v24 runtimes.
Deprecation Notice - https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/