### PR TITLE
chore: add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# formatting and linting
+638854444d0a2a339a7eb7abb8f232cba710b1bd

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -37,7 +37,7 @@ To set up the development environment, follow these steps:
 
    This command installs dependencies for development, including those for linting, formatting, spell-checking, and testing.
 
-1. Configure nbstripout to prevent notebook metadata noise in git diffs:
+1. Configure nbstripout to prevent notebook metadata noise in git diffs:q
 
    ```bash
    nbstripout --install --attributes .gitattributes
@@ -45,6 +45,12 @@ To set up the development environment, follow these steps:
    ```
 
    This ensures that environment-specific notebook metadata (like kernel names and Python versions) are automatically stripped when committing notebooks, while preserving cell outputs and execution counts.
+
+1. Configure git-blame-ignore-revs to remove noise in git blame:
+
+   ```bash
+   git config blame.ignoreRevsFile .git-blame-ignore-revs
+   ```
 
 1. You are now ready to work on the package!
 

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -37,7 +37,7 @@ To set up the development environment, follow these steps:
 
    This command installs dependencies for development, including those for linting, formatting, spell-checking, and testing.
 
-1. Configure nbstripout to prevent notebook metadata noise in git diffs:q
+1. Configure nbstripout to prevent notebook metadata noise in git diffs:
 
    ```bash
    nbstripout --install --attributes .gitattributes


### PR DESCRIPTION
This PR adds the .git-blame-ignore-revs config to ignore the formatting and linting commits in git blame.