### PR TITLE
fix: allow logical operators for one operand

### DIFF
--- a/langchain_hana/vectorstores/create_where_clause.py
+++ b/langchain_hana/vectorstores/create_where_clause.py
@@ -280,9 +280,9 @@ class CreateWhereClause:
             raise ValueError(
                 f"Operator {operator} expects a list of operands, but got {operands!r}"
             )
-        if len(operands) < 2:
+        if len(operands) < 1:
             raise ValueError(
-                f"Operator {operator} expects at least 2 operands, but got {operands!r}"
+                f"Operator {operator} expects at least 1 operand, but got {operands!r}"
             )
         if operator in ("$and", "$or"):
             sql_clauses, query_tuple = [], ()

--- a/tests/integration_tests/fixtures/filtering_test_cases.py
+++ b/tests/integration_tests/fixtures/filtering_test_cases.py
@@ -279,6 +279,20 @@ TYPE_2_FILTERING_TEST_CASES = [
 
 TYPE_3_FILTERING_TEST_CASES = [
     # These involve usage of AND and OR operators
+    # Single operand $or
+    (
+        {"$or": [{"id": 1}]},
+        [1],
+        "WHERE JSON_VALUE(VEC_META, '$.id') = TO_DOUBLE(?)",
+        (1,),
+    ),
+    # Single operand $and
+    (
+        {"$and": [{"name": "bob"}]},
+        [2],
+        "WHERE JSON_VALUE(VEC_META, '$.name') = TO_NVARCHAR(?)",
+        ("bob",),
+    ),
     (
         {"$or": [{"id": 1}, {"id": 2}]},
         [1, 2],
@@ -486,8 +500,12 @@ ERROR_FILTERING_TEST_CASES = [
     ),
     # # logical operators
     (
-        {"$or": [{"id": 1}]},
-        "Operator $or expects at least 2 operands, but got [{'id': 1}]",
+        {"$or": []},
+        "Operator $or expects at least 1 operand, but got []",
+    ),
+    (
+        {"$and": []},
+        "Operator $and expects at least 1 operand, but got []",
     ),
     ({"$and": "adam"}, "Operator $and expects a list of operands, but got 'adam'"),
     # # contains operator


### PR DESCRIPTION
Our previous versions allowed passing logical operators with a single operand.
This was changed in our validation checking pr, #71.

Thus in this PR, we relax the validation to allow passing one operand in our logical operations.
The test cases are added to check the functionality.