### PR TITLE
Default to read-only permissions in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ env:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     # The 'env:' block at the job level makes these variables available in all steps.
     env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,8 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out the repository
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
   check-prerelease-dependencies:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -28,6 +30,8 @@ jobs:
   run-tests:
     needs:
       - check-prerelease-dependencies
+    permissions:
+      contents: read
 
     uses: ./.github/workflows/ci.yml
     secrets:
@@ -46,6 +50,8 @@ jobs:
       - run-tests
     environment: Scheduled testing
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     outputs:
       pkg-name: ${{ steps.check-version.outputs.pkg-name }}


### PR DESCRIPTION
This PR changes workflow permissions to read-only (see: [docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions))