### PR TITLE
enh: add validation checks to prevent injection attacks

### DIFF
--- a/langchain_hana/graphs/hana_rdf_graph.py
+++ b/langchain_hana/graphs/hana_rdf_graph.py
@@ -71,7 +71,7 @@ class HanaRdfGraph:
     """
 
     # Characters forbidden inside a SPARQL IRIREF per the SPARQL 1.1 grammar.
-    _FORBIDDEN_IRI_CHARS = re.compile(r'[\x00-\x20<>"{}|\\^`]')
+    _FORBIDDEN_IRI_CHARS = re.compile(r'[\x00-\x20\x7f<>"{}|\\^`]')
 
     def __init__(
         self,

--- a/langchain_hana/graphs/hana_rdf_graph.py
+++ b/langchain_hana/graphs/hana_rdf_graph.py
@@ -70,6 +70,9 @@ class HanaRdfGraph:
         See https://python.langchain.com/docs/security for more information.
     """
 
+    # Characters forbidden inside a SPARQL IRIREF per the SPARQL 1.1 grammar.
+    _FORBIDDEN_IRI_CHARS = re.compile(r'[\x00-\x20<>"{}|\\^`]')
+
     def __init__(
         self,
         connection: dbapi.Connection,
@@ -88,6 +91,7 @@ class HanaRdfGraph:
         if not graph_uri or graph_uri.upper() == "DEFAULT":
             self.from_clause = "FROM DEFAULT"
         else:
+            HanaRdfGraph._validate_iri(graph_uri)
             self.from_clause = f"FROM <{graph_uri}>"
 
         self.refresh_schema(
@@ -97,6 +101,15 @@ class HanaRdfGraph:
             ontology_local_file_format,
             auto_extract_ontology,
         )
+
+    @staticmethod
+    def _validate_iri(uri: str) -> None:
+        """Raise ValueError if uri contains characters illegal in a SPARQL IRIREF."""
+        if HanaRdfGraph._FORBIDDEN_IRI_CHARS.search(uri):
+            raise ValueError(
+                f"Invalid IRI {uri!r}: contains characters not allowed "
+                "in a SPARQL IRI reference."
+            )
 
     def inject_from_clause(self, query: str) -> str:
         """
@@ -143,6 +156,10 @@ class HanaRdfGraph:
         if content_type is None:
             content_type = "application/sparql-results+csv"
 
+        if "\r" in content_type or "\n" in content_type:
+            raise ValueError(
+                "Invalid content_type: CR/LF characters are not permitted."
+            )
         request_headers = (
             f"Accept: {content_type}\r\nContent-Type: application/sparql-query"
         )
@@ -252,6 +269,7 @@ class HanaRdfGraph:
             )
         else:
             if ontology_uri:
+                HanaRdfGraph._validate_iri(ontology_uri)
                 ontology_query = (
                     f"CONSTRUCT {{?s ?p ?o}} FROM <{ontology_uri}> WHERE"
                     + "{?s ?p ?o .}"

--- a/langchain_hana/vectorstores/create_where_clause.py
+++ b/langchain_hana/vectorstores/create_where_clause.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Any, List, Tuple
 
+from langchain_hana.vectorstores.utils import _validate_identifier
+
 logger = logging.getLogger(__name__)
 
 
@@ -171,6 +173,7 @@ class CreateWhereClause:
         self, column: str, operator: str, operands: Any
     ) -> Tuple[str, tuple[Any, ...]]:
         if operator == "$contains":
+            _validate_identifier(column)
             operand = _determine_single_filter_operand(operator, operands)
             if operand.the_type != "str" or not operand.value:
                 raise ValueError(
@@ -302,6 +305,7 @@ class CreateWhereClause:
         raise ValueError(f"Operator {operator} is not supported")
 
     def _create_selector(self, column: str) -> str:
+        _validate_identifier(column)
         if column in self.specific_metadata_columns:
             return f'"{column}"'
         else:

--- a/langchain_hana/vectorstores/hana_db.py
+++ b/langchain_hana/vectorstores/hana_db.py
@@ -36,6 +36,7 @@ from langchain_hana.vectorstores.create_where_clause import (
 from langchain_hana.vectorstores.utils import (
     _generate_cross_encode_sql_and_params,
     _sanitize_metadata_keys,
+    _validate_identifier,
     _validate_rerank_model_id,
 )
 
@@ -138,6 +139,10 @@ class HanaDB(VectorStore):
                 embedding.get_remote_source_schema()
             )
             self.internal_embedding_remote_source = embedding.get_remote_source()
+            if self.internal_embedding_remote_source_schema:
+                _validate_identifier(self.internal_embedding_remote_source_schema)
+            if self.internal_embedding_remote_source:
+                _validate_identifier(self.internal_embedding_remote_source)
             self._validate_internal_embedding_function()
         else:
             # External embeddings

--- a/langchain_hana/vectorstores/utils.py
+++ b/langchain_hana/vectorstores/utils.py
@@ -7,12 +7,12 @@ from hdbcli import dbapi
 
 logger = logging.getLogger(__name__)
 
-_VALID_IDENTIFIER_RE = re.compile(r"^[_a-zA-Z][_a-zA-Z0-9]*$")
+_VALID_IDENTIFIER_RE = re.compile(r"[_a-zA-Z][_a-zA-Z0-9]*")
 
 
 def _validate_identifier(name: str) -> None:
     """Raise ValueError if name is not a safe SQL/JSON identifier."""
-    if not _VALID_IDENTIFIER_RE.match(name):
+    if not _VALID_IDENTIFIER_RE.fullmatch(name):
         raise ValueError(
             f"Invalid identifier {name!r}: only letters, digits, and underscores "
             "are allowed, and it must not start with a digit."

--- a/langchain_hana/vectorstores/utils.py
+++ b/langchain_hana/vectorstores/utils.py
@@ -2,21 +2,27 @@
 
 import logging
 import re
-from typing import Pattern
 
 from hdbcli import dbapi
 
 logger = logging.getLogger(__name__)
 
-# Compiled pattern for validating metadata identifiers
-_compiled_pattern: Pattern = re.compile("^[_a-zA-Z][_a-zA-Z0-9]*$")
+_VALID_IDENTIFIER_RE = re.compile(r"^[_a-zA-Z][_a-zA-Z0-9]*$")
+
+
+def _validate_identifier(name: str) -> None:
+    """Raise ValueError if name is not a safe SQL/JSON identifier."""
+    if not _VALID_IDENTIFIER_RE.match(name):
+        raise ValueError(
+            f"Invalid identifier {name!r}: only letters, digits, and underscores "
+            "are allowed, and it must not start with a digit."
+        )
 
 
 def _sanitize_metadata_keys(metadata_keys: list[str]) -> None:
     """Validate that all metadata keys are valid identifiers."""
     for key in metadata_keys:
-        if not _compiled_pattern.match(key):
-            raise ValueError(f"Invalid metadata key {key}")
+        _validate_identifier(key)
 
 
 def _validate_rerank_model_id(model_id: str, connection: dbapi.Connection) -> None:

--- a/tests/fixtures/filtering_test_cases.py
+++ b/tests/fixtures/filtering_test_cases.py
@@ -366,7 +366,7 @@ TYPE_4B_FILTERING_TEST_CASES = [
 ]
 
 TYPE_5_FILTERING_TEST_CASES = [
-    # These involve special operators like $like, $ilike that
+    # These involve special operators like $like, $contains that
     # may be specified to certain databases.
     (
         {"name": {"$like": "a%"}},
@@ -379,6 +379,20 @@ TYPE_5_FILTERING_TEST_CASES = [
         [1, 3],
         "WHERE JSON_VALUE(VEC_META, '$.name') LIKE TO_NVARCHAR(?)",
         ("%a%",),
+    ),
+    # $contains uses HANA full-text SCORE() on a quoted column identifier.
+    # Non-specific columns are projected via a CTE before the WHERE clause runs.
+    (
+        {"name": {"$contains": "adam"}},
+        [1],
+        "WHERE SCORE(TO_NVARCHAR(?) IN (\"name\" EXACT SEARCH MODE 'text')) > 0",
+        ("adam",),
+    ),
+    (
+        {"name": {"$contains": "bob"}},
+        [2],
+        "WHERE SCORE(TO_NVARCHAR(?) IN (\"name\" EXACT SEARCH MODE 'text')) > 0",
+        ("bob",),
     ),
 ]
 

--- a/tests/integration_tests/test_hana_reranker.py
+++ b/tests/integration_tests/test_hana_reranker.py
@@ -94,7 +94,13 @@ def test_rerank_with_invalid_top_n(
 def test_rerank_with_invalid_metadata_key(
     reranker: HanaReranker, documents: list[Document]
 ) -> None:
-    with pytest.raises(ValueError, match="Invalid metadata key invalid-key"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Invalid identifier 'invalid-key': only letters, digits, and"
+            " underscores are allowed, and it must not start with a digit."
+        ),
+    ):
         reranker.rerank(
             documents, HanaTestConstants.TEXTS[0], rank_fields=["invalid-key"]
         )

--- a/tests/unit_tests/test_create_where_clause.py
+++ b/tests/unit_tests/test_create_where_clause.py
@@ -49,3 +49,44 @@ def test_create_where_clause_invalid_filters(
 ) -> None:
     with pytest.raises(ValueError, match=re.escape(expected_exception_message)):
         CreateWhereClause(MockHanaDb())(test_filter)
+
+
+# ---------------------------------------------------------------------------
+# SQL injection guard tests
+# ---------------------------------------------------------------------------
+
+_INJECTION_COLUMN_NAMES = [
+    "col') FROM DUAL UNION SELECT * FROM SYS.USERS--",
+    'col"evil',
+    "col; DROP TABLE users--",
+    "col OR 1=1",
+    "col/*comment*/",
+    "1col",  # starts with digit
+    "col name",  # space
+    "col-name",  # hyphen
+    "col.name",  # dot
+]
+
+
+@pytest.mark.parametrize("bad_column", _INJECTION_COLUMN_NAMES)
+def test_sql_injection_via_filter_key_raises(bad_column: str) -> None:
+    """Malicious filter keys must raise ValueError, not reach the query string."""
+    with pytest.raises(ValueError, match="Invalid identifier"):
+        CreateWhereClause(MockHanaDb())({bad_column: "value"})
+
+
+@pytest.mark.parametrize("bad_column", _INJECTION_COLUMN_NAMES)
+def test_sql_injection_via_contains_filter_key_raises(bad_column: str) -> None:
+    """Malicious column names in $contains must raise ValueError."""
+    with pytest.raises(ValueError, match="Invalid identifier"):
+        CreateWhereClause(MockHanaDb())({bad_column: {"$contains": "search term"}})
+
+
+@pytest.mark.parametrize(
+    "good_column",
+    ["name", "my_column", "_private", "col123", "CamelCase"],
+)
+def test_valid_column_names_accepted(good_column: str) -> None:
+    """Valid identifier column names must not raise."""
+    clause, params = CreateWhereClause(MockHanaDb())({good_column: "value"})
+    assert good_column in clause

--- a/tests/unit_tests/test_hana_db.py
+++ b/tests/unit_tests/test_hana_db.py
@@ -1,8 +1,10 @@
 """Test HanaVector functionality."""
 
+from unittest.mock import Mock, patch
+
 import pytest
 
-from langchain_hana import HanaDB
+from langchain_hana import HanaDB, HanaInternalEmbeddings
 from langchain_hana.utils import _validate_k, _validate_k_and_fetch_k
 
 
@@ -117,3 +119,69 @@ def test_max_marginal_relevance_search_invalid(
 ) -> None:
     with pytest.raises(ValueError, match=match):
         dummy_max_marginal_relevance_search(query, k=k, fetch_k=fetch_k)
+
+
+# ---------------------------------------------------------------------------
+# SQL injection guard: remote_source and remote_source_schema
+# ---------------------------------------------------------------------------
+
+_BAD_IDENTIFIERS = [
+    "schema'; DROP TABLE users--",
+    "schema OR 1=1",
+    "schema name",
+    "1schema",
+    "schema-name",
+    "schema.name",
+]
+
+
+def _make_hana_db(embedding: HanaInternalEmbeddings) -> HanaDB:
+    with (
+        patch.object(HanaDB, "_initialize_table"),
+        patch.object(HanaDB, "_validate_internal_embedding_function"),
+        patch.object(
+            HanaDB, "_sanitize_vector_column_type", return_value="REAL_VECTOR"
+        ),
+    ):
+        return HanaDB(connection=Mock(), embedding=embedding)
+
+
+@pytest.mark.parametrize("bad_value", _BAD_IDENTIFIERS)
+def test_invalid_remote_source_schema_raises(bad_value: str) -> None:
+    embedding = HanaInternalEmbeddings(
+        internal_embedding_model_id="model",
+        remote_source_schema=bad_value,
+        remote_source="valid_source",
+    )
+    with pytest.raises(ValueError, match="Invalid identifier"):
+        _make_hana_db(embedding)
+
+
+@pytest.mark.parametrize("bad_value", _BAD_IDENTIFIERS)
+def test_invalid_remote_source_raises(bad_value: str) -> None:
+    embedding = HanaInternalEmbeddings(
+        internal_embedding_model_id="model",
+        remote_source_schema="valid_schema",
+        remote_source=bad_value,
+    )
+    with pytest.raises(ValueError, match="Invalid identifier"):
+        _make_hana_db(embedding)
+
+
+@pytest.mark.parametrize(
+    "schema, source",
+    [
+        ("valid_schema", "valid_source"),
+        ("", ""),
+        ("MySchema123", "MySource_456"),
+    ],
+)
+def test_valid_remote_source_and_schema_accepted(schema: str, source: str) -> None:
+    embedding = HanaInternalEmbeddings(
+        internal_embedding_model_id="model",
+        remote_source_schema=schema,
+        remote_source=source,
+    )
+    db = _make_hana_db(embedding)
+    assert db.internal_embedding_remote_source_schema == schema
+    assert db.internal_embedding_remote_source == source

--- a/tests/unit_tests/test_hana_db.py
+++ b/tests/unit_tests/test_hana_db.py
@@ -6,6 +6,7 @@ import pytest
 
 from langchain_hana import HanaDB, HanaInternalEmbeddings
 from langchain_hana.utils import _validate_k, _validate_k_and_fetch_k
+from langchain_hana.vectorstores.utils import _validate_identifier
 
 
 def test_int_sanitation_with_illegal_value() -> None:
@@ -132,7 +133,27 @@ _BAD_IDENTIFIERS = [
     "1schema",
     "schema-name",
     "schema.name",
+    "col\n",
+    "",
 ]
+
+_VALID_IDENTIFIERS = [
+    "valid_col",
+    "_leading_underscore",
+    "Col123",
+    "a",
+]
+
+
+@pytest.mark.parametrize("name", _VALID_IDENTIFIERS)
+def test_validate_identifier_accepts_valid_names(name: str) -> None:
+    _validate_identifier(name)  # must not raise
+
+
+@pytest.mark.parametrize("name", _BAD_IDENTIFIERS)
+def test_validate_identifier_rejects_invalid_names(name: str) -> None:
+    with pytest.raises(ValueError):
+        _validate_identifier(name)
 
 
 def _make_hana_db(embedding: HanaInternalEmbeddings) -> HanaDB:
@@ -146,7 +167,7 @@ def _make_hana_db(embedding: HanaInternalEmbeddings) -> HanaDB:
         return HanaDB(connection=Mock(), embedding=embedding)
 
 
-@pytest.mark.parametrize("bad_value", _BAD_IDENTIFIERS)
+@pytest.mark.parametrize("bad_value", [v for v in _BAD_IDENTIFIERS if v])
 def test_invalid_remote_source_schema_raises(bad_value: str) -> None:
     embedding = HanaInternalEmbeddings(
         internal_embedding_model_id="model",
@@ -157,7 +178,7 @@ def test_invalid_remote_source_schema_raises(bad_value: str) -> None:
         _make_hana_db(embedding)
 
 
-@pytest.mark.parametrize("bad_value", _BAD_IDENTIFIERS)
+@pytest.mark.parametrize("bad_value", [v for v in _BAD_IDENTIFIERS if v])
 def test_invalid_remote_source_raises(bad_value: str) -> None:
     embedding = HanaInternalEmbeddings(
         internal_embedding_model_id="model",
@@ -170,11 +191,7 @@ def test_invalid_remote_source_raises(bad_value: str) -> None:
 
 @pytest.mark.parametrize(
     "schema, source",
-    [
-        ("valid_schema", "valid_source"),
-        ("", ""),
-        ("MySchema123", "MySource_456"),
-    ],
+    [(v, v) for v in _VALID_IDENTIFIERS],
 )
 def test_valid_remote_source_and_schema_accepted(schema: str, source: str) -> None:
     embedding = HanaInternalEmbeddings(

--- a/tests/unit_tests/test_hana_rdf_graph.py
+++ b/tests/unit_tests/test_hana_rdf_graph.py
@@ -1,33 +1,134 @@
 """Test HANA RDF Graph unit tests."""
 
+from typing import Any, Optional
 from unittest.mock import Mock, patch
 
+import pytest
 import rdflib
 
 from langchain_hana import HanaRdfGraph
 
 
-def test_get_schema_returns_graph_not_string_issue_45() -> None:
-    """Test that verifies the fix for GitHub issue #45"""
-    # Mock the database connection since this is a unit test
-    mock_connection = Mock()
-
-    # Create a minimal schema graph for testing
+def _mock_graph(
+    mock_connection: Mock,
+    graph_uri: str = "",
+    ontology_uri: Optional[str] = None,
+    auto_extract_ontology: bool = True,
+) -> HanaRdfGraph:
+    """Return a HanaRdfGraph with all DB calls patched out."""
     test_schema = rdflib.Graph()
-    test_schema.add(
-        (rdflib.URIRef("http://example.org/Person"), rdflib.RDF.type, rdflib.RDFS.Class)
-    )
+    kwargs: dict[str, Any] = dict(connection=mock_connection)
+    if graph_uri:
+        kwargs["graph_uri"] = graph_uri
+    if ontology_uri is not None:
+        kwargs["ontology_uri"] = ontology_uri
+        auto_extract_ontology = False
+    kwargs["auto_extract_ontology"] = auto_extract_ontology
 
-    # Mock the HanaRdfGraph to avoid database dependency
     with patch.object(
         HanaRdfGraph, "_load_ontology_schema_graph_from_query", return_value=test_schema
     ), patch.object(HanaRdfGraph, "_validate_construct_query"):
-        graph = HanaRdfGraph(
-            connection=mock_connection,
+        return HanaRdfGraph(**kwargs)
+
+
+def test_get_schema_returns_graph_not_string_issue_45() -> None:
+    """Test that verifies the fix for GitHub issue #45"""
+    graph = _mock_graph(Mock())
+    schema_graph = graph.get_schema
+    assert isinstance(
+        schema_graph, rdflib.Graph
+    ), "graph.get_schema returns a string instead of a rdflib.Graph object"
+
+
+# ---------------------------------------------------------------------------
+# IRI injection guard tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_uri",
+    [
+        "http://example.com/graph> WHERE {?s ?p ?o} #",
+        'http://example.com/graph"evil',
+        "http://example.com/{graph}",
+        "http://example.com/graph|pipe",
+        "http://example.com/graph\\backslash",
+        "http://example.com/graph^caret",
+        "http://example.com/graph`tick",
+        "http://example.com/graph\x00null",
+        "http://example.com/graph\x01control",
+    ],
+)
+def test_validate_iri_raises_on_forbidden_chars(bad_uri: str) -> None:
+    with pytest.raises(ValueError, match="Invalid IRI"):
+        HanaRdfGraph._validate_iri(bad_uri)
+
+
+@pytest.mark.parametrize(
+    "good_uri",
+    [
+        "http://example.com/graph",
+        "http://example.com/ontology#Class",
+        "urn:example:graph",
+        "https://dbpedia.org/ontology/Person",
+    ],
+)
+def test_validate_iri_accepts_valid_uris(good_uri: str) -> None:
+    HanaRdfGraph._validate_iri(good_uri)  # must not raise
+
+
+def test_graph_uri_with_injection_raises_on_init() -> None:
+    with pytest.raises(ValueError, match="Invalid IRI"):
+        HanaRdfGraph(
+            connection=Mock(),
+            graph_uri="http://x.com/g> UNION SELECT * WHERE {?s ?p ?o}",
             auto_extract_ontology=True,
         )
 
-        schema_graph = graph.get_schema
-        assert isinstance(
-            schema_graph, rdflib.Graph
-        ), "graph.get_schema returns a string instead of a rdflib.Graph object"
+
+def test_graph_uri_valid_sets_from_clause() -> None:
+    graph = _mock_graph(Mock(), graph_uri="http://example.com/mygraph")
+    assert graph.from_clause == "FROM <http://example.com/mygraph>"
+
+
+def test_ontology_uri_with_injection_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid IRI"):
+        _mock_graph(Mock(), ontology_uri="http://x.com/ont> INJECT")
+
+
+def test_ontology_uri_valid_does_not_raise() -> None:
+    _mock_graph(Mock(), ontology_uri="http://example.com/ontology")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# HTTP header injection guard tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_content_type",
+    [
+        "text/csv\r\nX-Injected: evil",
+        "text/csv\nX-Injected: evil",
+        "text/csv\rX-Injected: evil",
+    ],
+)
+def test_query_raises_on_crlf_in_content_type(bad_content_type: str) -> None:
+    graph = _mock_graph(Mock())
+    with pytest.raises(ValueError, match="CR/LF"):
+        graph.query("SELECT ?s WHERE { ?s ?p ?o }", content_type=bad_content_type)
+
+
+def test_query_accepts_valid_content_type() -> None:
+    mock_connection = Mock()
+    mock_cursor = Mock()
+    mock_cursor.callproc.return_value = (None, None, "s\nhttp://example.com/a\n")
+    mock_connection.cursor.return_value = mock_cursor
+
+    graph = _mock_graph(mock_connection)
+    result = graph.query(
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        content_type="application/sparql-results+csv",
+        inject_from_clause=False,
+    )
+    assert isinstance(result, str)


### PR DESCRIPTION
This PR adds the validation checks for variables used in format strings to prevent injection attacks.

1. `HanaRdfGraph` -> validation for IRIs which are used in SPARQL queries, validation of HTTP Headers.
2. `CreateWhereClause` -> validation for column names
3. `HanaInternalEmbeddings` -> validation for remote source and remote source schema name identifiers

Unit tests are added to test the correctness of the validation functions.